### PR TITLE
Replace AsyncImage with KFImage for better image caching

### DIFF
--- a/PictureBookLendingAdminApp/PictureBookLendingUI/Package.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingUI/Package.swift
@@ -16,7 +16,8 @@ let package = Package(
             targets: ["PictureBookLendingUI"])
     ],
     dependencies: [
-        .package(path: "../PictureBookLendingDomain")
+        .package(path: "../PictureBookLendingDomain"),
+        .package(url: "https://github.com/onevcat/Kingfisher.git", from: "8.5.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.
@@ -24,7 +25,8 @@ let package = Package(
         .target(
             name: "PictureBookLendingUI",
             dependencies: [
-                .product(name: "PictureBookLendingDomain", package: "PictureBookLendingDomain")
+                .product(name: "PictureBookLendingDomain", package: "PictureBookLendingDomain"),
+                .product(name: "Kingfisher", package: "Kingfisher")
             ]
         ),
         .testTarget(

--- a/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookDetailView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookDetailView.swift
@@ -1,3 +1,4 @@
+import Kingfisher
 import PictureBookLendingDomain
 import SwiftUI
 
@@ -29,16 +30,14 @@ public struct BookDetailView<ActionButton: View>: View {
                 HStack {
                     Spacer()
                     
-                    AsyncImage(url: URL(string: book.thumbnail ?? book.smallThumbnail ?? "")) {
-                        image in
-                        image
-                            .resizable()
-                            .aspectRatio(contentMode: .fit)
-                    } placeholder: {
-                        Image(systemName: "book.closed")
-                            .foregroundStyle(.secondary)
-                            .font(.system(size: 48))
-                    }
+                    KFImage(URL(string: book.thumbnail ?? book.smallThumbnail ?? ""))
+                        .placeholder {
+                            Image(systemName: "book.closed")
+                                .foregroundStyle(.secondary)
+                                .font(.system(size: 48))
+                        }
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
                     .frame(width: 120, height: 160)
                     .background(.regularMaterial)
                     .clipShape(RoundedRectangle(cornerRadius: 8))

--- a/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookListView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookListView.swift
@@ -1,3 +1,4 @@
+import Kingfisher
 import PictureBookLendingDomain
 import SwiftUI
 
@@ -54,15 +55,14 @@ public struct BookRowView<RowAction: View>: View {
     public var body: some View {
         HStack {
             // サムネイル画像
-            AsyncImage(url: URL(string: book.thumbnail ?? book.smallThumbnail ?? "")) { image in
-                image
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-            } placeholder: {
-                Image(systemName: "book.closed")
-                    .foregroundStyle(.secondary)
-                    .font(.title2)
-            }
+            KFImage(URL(string: book.thumbnail ?? book.smallThumbnail ?? ""))
+                .placeholder {
+                    Image(systemName: "book.closed")
+                        .foregroundStyle(.secondary)
+                        .font(.title2)
+                }
+                .resizable()
+                .aspectRatio(contentMode: .fit)
             .frame(width: 50, height: 65)
             .background(.regularMaterial)
             .clipShape(RoundedRectangle(cornerRadius: 6))

--- a/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookSearchView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookSearchView.swift
@@ -1,3 +1,4 @@
+import Kingfisher
 import PictureBookLendingDomain
 import SwiftUI
 
@@ -312,18 +313,14 @@ struct SearchResultRow: View {
         Button(action: onTap) {
             HStack {
                 // サムネイル画像
-                AsyncImage(
-                    url: URL(
-                        string: scoredBook.book.thumbnail ?? scoredBook.book.smallThumbnail ?? "")
-                ) { image in
-                    image
-                        .resizable()
-                        .aspectRatio(contentMode: .fit)
-                } placeholder: {
-                    Image(systemName: "book.closed")
-                        .foregroundStyle(.secondary)
-                        .font(.title2)
-                }
+                KFImage(URL(string: scoredBook.book.thumbnail ?? scoredBook.book.smallThumbnail ?? ""))
+                    .placeholder {
+                        Image(systemName: "book.closed")
+                            .foregroundStyle(.secondary)
+                            .font(.title2)
+                    }
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
                 .frame(width: 60, height: 80)
                 .background(.regularMaterial)
                 .clipShape(RoundedRectangle(cornerRadius: 6))

--- a/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Loan/LoanListView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Loan/LoanListView.swift
@@ -1,3 +1,4 @@
+import Kingfisher
 import PictureBookLendingDomain
 import SwiftUI
 
@@ -170,16 +171,14 @@ private struct LoanListRowView<Action: View>: View {
     var body: some View {
         HStack {
             // サムネイル画像
-            AsyncImage(url: URL(string: loan.bookThumbnail ?? loan.bookSmallThumbnail ?? "")) {
-                image in
-                image
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-            } placeholder: {
-                Image(systemName: "book.closed")
-                    .foregroundStyle(.secondary)
-                    .font(.title2)
-            }
+            KFImage(URL(string: loan.bookThumbnail ?? loan.bookSmallThumbnail ?? ""))
+                .placeholder {
+                    Image(systemName: "book.closed")
+                        .foregroundStyle(.secondary)
+                        .font(.title2)
+                }
+                .resizable()
+                .aspectRatio(contentMode: .fit)
             .frame(width: 50, height: 65)
             .background(.regularMaterial)
             .clipShape(RoundedRectangle(cornerRadius: 6))


### PR DESCRIPTION
AsyncImageをKFImageに置き換えてキャッシュ機能を有効にしました。

## 変更内容
- Kingfisherライブラリを8.5.0をPictureBookLendingUIモジュールに追加
- 4つのファイルでAsyncImageをKFImageに置き換え
- swift-tools-version 6.2を維持
- 画像のメモリキャッシュ機能を有効化

## ファイル変更
- `BookDetailView.swift` - 絵本詳細のサムネイル表示
- `BookListView.swift` - 絵本一覧の行表示
- `BookSearchView.swift` - 検索結果の表示
- `LoanListView.swift` - 貸出記錄の表示

Closes #59

🤖 Generated with [Claude Code](https://claude.ai/code)