### PR TITLE
feat: 返却期限管理と絵本管理機能の改善

### DIFF
--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/BookFormContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/BookFormContainerView.swift
@@ -17,6 +17,7 @@ struct BookFormContainerView: View {
     
     @State private var title = ""
     @State private var author = ""
+    @State private var managementNumber = ""
     @State private var alertState = AlertState()
     
     var body: some View {
@@ -24,6 +25,7 @@ struct BookFormContainerView: View {
             BookFormView(
                 title: $title,
                 author: $author,
+                managementNumber: $managementNumber,
                 mode: mode,
                 onSave: handleSave,
                 onCancel: handleCancel
@@ -34,6 +36,7 @@ struct BookFormContainerView: View {
                 if case .edit(let book) = mode {
                     title = book.title
                     author = book.author
+                    managementNumber = book.managementNumber ?? ""
                 }
             }
             .alert(alertState.title, isPresented: $alertState.isPresented) {
@@ -60,7 +63,11 @@ struct BookFormContainerView: View {
         do {
             switch mode {
             case .add:
-                let newBook = Book(title: title, author: author)
+                let newBook = Book(
+                    title: title,
+                    author: author,
+                    managementNumber: managementNumber
+                )
                 let savedBook = try bookModel.registerBook(newBook)
                 onSave?(savedBook)
 
@@ -68,7 +75,17 @@ struct BookFormContainerView: View {
                 let updatedBook = Book(
                     id: book.id,
                     title: title,
-                    author: author
+                    author: author,
+                    isbn13: book.isbn13,
+                    publisher: book.publisher,
+                    publishedDate: book.publishedDate,
+                    description: book.description,
+                    smallThumbnail: book.smallThumbnail,
+                    thumbnail: book.thumbnail,
+                    targetAge: book.targetAge,
+                    pageCount: book.pageCount,
+                    categories: book.categories,
+                    managementNumber: managementNumber.isEmpty ? nil : managementNumber
                 )
                 let savedBook = try bookModel.updateBook(updatedBook)
                 onSave?(savedBook)

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/SettingsBookListContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/SettingsBookListContainerView.swift
@@ -47,14 +47,25 @@ struct SettingsBookListContainerView: View {
                 }
             }
         }
-        .sheet(isPresented: $isAddSheetPresented) {
-            BookFormContainerView(
-                mode: .add,
-                onSave: { _ in
-                    // 追加成功時にシートを閉じる処理は既にContainerView内で実行される
-                }
-            )
-        }
+        #if os(macOS)
+            .sheet(isPresented: $isAddSheetPresented) {
+                BookFormContainerView(
+                    mode: .add,
+                    onSave: { _ in
+                        // 追加成功時にシートを閉じる処理は既にContainerView内で実行される
+                    }
+                )
+            }
+        #else
+            .fullScreenCover(isPresented: $isAddSheetPresented) {
+                BookFormContainerView(
+                    mode: .add,
+                    onSave: { _ in
+                        // 追加成功時にシートを閉じる処理は既にContainerView内で実行される
+                    }
+                )
+            }
+        #endif
         .alert(alertState.title, isPresented: $alertState.isPresented) {
             Button("OK", role: .cancel) {}
         } message: {

--- a/PictureBookLendingAdminApp/PictureBookLendingDomain/Sources/PictureBookLendingDomain/Domain/Book.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingDomain/Sources/PictureBookLendingDomain/Domain/Book.swift
@@ -27,6 +27,8 @@ public struct Book: Identifiable, Codable, Hashable, Sendable {
     public var pageCount: Int?
     /// カテゴリ・ジャンル
     public var categories: [String]
+    /// 独自の管理番号
+    public var managementNumber: String?
     
     /// 絵本モデルの初期化（完全版）
     /// - Parameters:
@@ -42,6 +44,7 @@ public struct Book: Identifiable, Codable, Hashable, Sendable {
     ///   - targetAge: 対象年齢（任意）
     ///   - pageCount: ページ数（任意）
     ///   - categories: カテゴリ・ジャンル（デフォルトは空配列）
+    ///   - managementNumber: 独自の管理番号（任意）
     public init(
         id: UUID = UUID(),
         title: String,
@@ -54,11 +57,13 @@ public struct Book: Identifiable, Codable, Hashable, Sendable {
         thumbnail: String? = nil,
         targetAge: Int? = nil,
         pageCount: Int? = nil,
-        categories: [String] = []
+        categories: [String] = [],
+        managementNumber: String? = nil
     ) {
         self.id = id
         self.title = title
         self.author = author
+        self.managementNumber = managementNumber
         self.isbn13 = isbn13
         self.publisher = publisher
         self.publishedDate = publishedDate
@@ -88,5 +93,6 @@ public struct Book: Identifiable, Codable, Hashable, Sendable {
         self.targetAge = nil
         self.pageCount = nil
         self.categories = []
+        self.managementNumber = nil
     }
 }

--- a/PictureBookLendingAdminApp/PictureBookLendingInfrastructure/Sources/PictureBookLendingInfrastructure/Gateways/GoogleBookSearchGateway.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingInfrastructure/Sources/PictureBookLendingInfrastructure/Gateways/GoogleBookSearchGateway.swift
@@ -242,7 +242,8 @@ public struct GoogleBookSearchGateway: BookSearchGatewayProtocol, Sendable {
             thumbnail: thumbnail,
             targetAge: nil,  // APIからは取得できないため、後でユーザーが設定
             pageCount: volumeInfo.pageCount,
-            categories: volumeInfo.categories ?? []
+            categories: volumeInfo.categories ?? [],
+            managementNumber: nil
         )
     }
 }

--- a/PictureBookLendingAdminApp/PictureBookLendingInfrastructure/Sources/PictureBookLendingInfrastructure/Mocks/MockRepositories.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingInfrastructure/Sources/PictureBookLendingInfrastructure/Mocks/MockRepositories.swift
@@ -232,7 +232,8 @@ public final class MockBookSearchGateway: BookSearchGatewayProtocol {
             thumbnail: "https://example.com/thumbnail.jpg",
             targetAge: 3,
             pageCount: 32,
-            categories: ["絵本", "テスト"]
+            categories: ["絵本", "テスト"],
+            managementNumber: "テスト\(isbn.suffix(3))"
         )
     }
     
@@ -253,7 +254,8 @@ public final class MockBookSearchGateway: BookSearchGatewayProtocol {
                 thumbnail: "https://example.com/thumbnail\(i).jpg",
                 targetAge: 2 + i,
                 pageCount: 30 + i * 2,
-                categories: ["絵本", "テスト"]
+                categories: ["絵本", "テスト"],
+                managementNumber: "テスト\(i)"
             )
             books.append(book)
         }

--- a/PictureBookLendingAdminApp/PictureBookLendingInfrastructure/Sources/PictureBookLendingInfrastructure/Repositories/SwiftDataBook.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingInfrastructure/Sources/PictureBookLendingInfrastructure/Repositories/SwiftDataBook.swift
@@ -19,6 +19,9 @@ final public class SwiftDataBook {
     /// 著者名
     public var author: String
     
+    /// 独自の管理番号
+    public var managementNumber: String?
+    
     /// ISBN-13コード
     public var isbn13: String?
     
@@ -53,6 +56,7 @@ final public class SwiftDataBook {
     ///   - id: 絵本の一意識別子
     ///   - title: 絵本のタイトル
     ///   - author: 著者名
+    ///   - managementNumber: 独自の管理番号
     ///   - isbn13: ISBN-13コード
     ///   - publisher: 出版社名
     ///   - publishedDate: 出版日
@@ -74,11 +78,13 @@ final public class SwiftDataBook {
         thumbnail: String? = nil,
         targetAge: Int? = nil,
         pageCount: Int? = nil,
-        categories: [String] = []
+        categories: [String] = [],
+        managementNumber: String? = nil
     ) {
         self.id = id
         self.title = title
         self.author = author
+        self.managementNumber = managementNumber
         self.isbn13 = isbn13
         self.publisher = publisher
         self.publishedDate = publishedDate

--- a/PictureBookLendingAdminApp/PictureBookLendingInfrastructure/Sources/PictureBookLendingInfrastructure/Repositories/SwiftDataBookRepository.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingInfrastructure/Sources/PictureBookLendingInfrastructure/Repositories/SwiftDataBookRepository.swift
@@ -34,7 +34,8 @@ public final class SwiftDataBookRepository: BookRepositoryProtocol, @unchecked S
             thumbnail: book.thumbnail,
             targetAge: book.targetAge,
             pageCount: book.pageCount,
-            categories: book.categories
+            categories: book.categories,
+            managementNumber: book.managementNumber
         )
         
         modelContext.insert(swiftDataBook)
@@ -70,7 +71,8 @@ public final class SwiftDataBookRepository: BookRepositoryProtocol, @unchecked S
                     thumbnail: swiftDataBook.thumbnail,
                     targetAge: swiftDataBook.targetAge,
                     pageCount: swiftDataBook.pageCount,
-                    categories: swiftDataBook.categories
+                    categories: swiftDataBook.categories,
+                    managementNumber: swiftDataBook.managementNumber
                 )
             }
         } catch {
@@ -105,7 +107,8 @@ public final class SwiftDataBookRepository: BookRepositoryProtocol, @unchecked S
                 thumbnail: swiftDataBook.thumbnail,
                 targetAge: swiftDataBook.targetAge,
                 pageCount: swiftDataBook.pageCount,
-                categories: swiftDataBook.categories
+                categories: swiftDataBook.categories,
+                managementNumber: swiftDataBook.managementNumber
             )
         } catch {
             throw RepositoryError.fetchFailed
@@ -130,6 +133,7 @@ public final class SwiftDataBookRepository: BookRepositoryProtocol, @unchecked S
             // プロパティを更新
             swiftDataBook.title = book.title
             swiftDataBook.author = book.author
+            swiftDataBook.managementNumber = book.managementNumber
             swiftDataBook.isbn13 = book.isbn13
             swiftDataBook.publisher = book.publisher
             swiftDataBook.publishedDate = book.publishedDate

--- a/PictureBookLendingAdminApp/PictureBookLendingModel/Sources/PictureBookLendingModel/RegisterModel.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingModel/Sources/PictureBookLendingModel/RegisterModel.swift
@@ -192,7 +192,8 @@ public class RegisterModel {
                 thumbnail: nil,
                 targetAge: 3,  // デフォルト対象年齢
                 pageCount: nil,
-                categories: []
+                categories: [],
+                managementNumber: ""
             )
         }
     }

--- a/PictureBookLendingAdminApp/PictureBookLendingModel/Tests/PictureBookLendingModelTests/BookModelTests.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingModel/Tests/PictureBookLendingModelTests/BookModelTests.swift
@@ -31,7 +31,7 @@ struct BookModelTests {
     func registerBook() throws {
         // 1. Arrange - 準備
         let (bookModel, _) = createBookModel()
-        let book = Book(title: "はらぺこあおむし", author: "エリック・カール")
+        let book = Book(title: "はらぺこあおむし", author: "エリック・カール", managementNumber: "あ001")
         
         // 2. Act - 実行
         let registeredBook = try bookModel.registerBook(book)
@@ -51,8 +51,8 @@ struct BookModelTests {
     func getAllBooks() throws {
         // 1. Arrange - 準備
         let (bookModel, _) = createBookModel()
-        let book1 = Book(title: "はらぺこあおむし", author: "エリック・カール")
-        let book2 = Book(title: "ぐりとぐら", author: "中川李枝子")
+        let book1 = Book(title: "はらぺこあおむし", author: "エリック・カール", managementNumber: "あ001")
+        let book2 = Book(title: "ぐりとぐら", author: "中川李枝子", managementNumber: "あ002")
         
         // 2. Act - 実行
         _ = try bookModel.registerBook(book1)
@@ -72,7 +72,7 @@ struct BookModelTests {
     func findBookById() throws {
         // 1. Arrange - 準備
         let (bookModel, _) = createBookModel()
-        let book = Book(title: "はらぺこあおむし", author: "エリック・カール")
+        let book = Book(title: "はらぺこあおむし", author: "エリック・カール", managementNumber: "あ001")
         let registeredBook = try bookModel.registerBook(book)
         let id = registeredBook.id
         
@@ -92,7 +92,7 @@ struct BookModelTests {
     func updateBook() throws {
         // 1. Arrange - 準備
         let (bookModel, _) = createBookModel()
-        let book = Book(title: "はらぺこあおむし", author: "エリック・カール")
+        let book = Book(title: "はらぺこあおむし", author: "エリック・カール", managementNumber: "あ001")
         let registeredBook = try bookModel.registerBook(book)
         let id = registeredBook.id
         
@@ -117,7 +117,7 @@ struct BookModelTests {
     func deleteBook() throws {
         // 1. Arrange - 準備
         let (bookModel, _) = createBookModel()
-        let book = Book(title: "はらぺこあおむし", author: "エリック・カール")
+        let book = Book(title: "はらぺこあおむし", author: "エリック・カール", managementNumber: "あ001")
         let registeredBook = try bookModel.registerBook(book)
         let id = registeredBook.id
         

--- a/PictureBookLendingAdminApp/PictureBookLendingModel/Tests/PictureBookLendingModelTests/LoanModelTests.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingModel/Tests/PictureBookLendingModelTests/LoanModelTests.swift
@@ -32,7 +32,7 @@ struct LoanModelTests {
         let classGroup = ClassGroup(name: "1年2組", ageGroup: 6, year: 2025)
         try mockRepositoryFactory.classGroupRepository.save(classGroup)
         
-        let initialBook = Book(title: "はらぺこあおむし", author: "エリック・カール")
+        let initialBook = Book(title: "はらぺこあおむし", author: "エリック・カール", managementNumber: "あ001")
         let initialUser = User(name: "山田太郎", classGroupId: classGroup.id)
         
         // 本とユーザーを登録

--- a/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookDetailView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookDetailView.swift
@@ -58,6 +58,9 @@ public struct BookDetailView<ActionButton: View>: View {
             Section("基本情報") {
                 EditableDetailRow(label: "タイトル", value: $book.title)
                 EditableDetailRow(label: "著者", value: $book.author)
+                if let managementNumber = book.managementNumber, !managementNumber.isEmpty {
+                    DetailRow(label: "管理番号", value: managementNumber)
+                }
                 DetailRow(label: "管理ID", value: book.id.uuidString)
             }
             

--- a/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookFormView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookFormView.swift
@@ -8,6 +8,7 @@ import SwiftUI
 public struct BookFormView: View {
     @Binding var title: String
     @Binding var author: String
+    @Binding var managementNumber: String
     let mode: BookFormMode
     let onSave: () -> Void
     let onCancel: () -> Void
@@ -15,12 +16,14 @@ public struct BookFormView: View {
     public init(
         title: Binding<String>,
         author: Binding<String>,
+        managementNumber: Binding<String>,
         mode: BookFormMode,
         onSave: @escaping () -> Void,
         onCancel: @escaping () -> Void
     ) {
         self._title = title
         self._author = author
+        self._managementNumber = managementNumber
         self.mode = mode
         self.onSave = onSave
         self.onCancel = onCancel
@@ -31,6 +34,7 @@ public struct BookFormView: View {
             Section(header: Text("絵本情報")) {
                 TextField("タイトル", text: $title)
                 TextField("著者", text: $author)
+                TextField("管理番号（例: あ13）", text: $managementNumber)
             }
         }
         .toolbar {
@@ -69,6 +73,7 @@ public struct BookFormView: View {
         BookFormView(
             title: .constant("サンプル本"),
             author: .constant("著者名"),
+            managementNumber: .constant("あ13"),
             mode: .add,
             onSave: {},
             onCancel: {}

--- a/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookFormView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookFormView.swift
@@ -25,9 +25,9 @@ public struct BookFormView: View {
     
     public var body: some View {
         Form {
-            Section(header: Text("基本情報")) {
-                TextField("タイトル", text: $book.title)
-                TextField("著者", text: $book.author)
+            Section(header: Text("基本情報（*は必須）")) {
+                TextField("タイトル *", text: $book.title)
+                TextField("著者 *", text: $book.author)
                 TextField(
                     "管理番号（例: あ13）",
                     text: Binding(
@@ -36,7 +36,7 @@ public struct BookFormView: View {
                     ))
             }
             
-            Section(header: Text("詳細情報")) {
+            Section(header: Text("詳細情報（任意）")) {
                 TextField(
                     "ISBN-13",
                     text: Binding(
@@ -57,7 +57,7 @@ public struct BookFormView: View {
                     ))
             }
             
-            Section(header: Text("その他")) {
+            Section(header: Text("その他（任意）")) {
                 Stepper(
                     "対象年齢: \(book.targetAge ?? 0)歳",
                     value: Binding(
@@ -83,7 +83,7 @@ public struct BookFormView: View {
                 #endif
             }
             
-            Section(header: Text("説明")) {
+            Section(header: Text("説明（任意）")) {
                 TextField(
                     "絵本の説明・あらすじ",
                     text: Binding(

--- a/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookFormView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookFormView.swift
@@ -6,24 +6,18 @@ import SwiftUI
 /// 純粋なUI表示のみを担当し、NavigationStack、alert等の
 /// 画面制御はContainer Viewに委譲します。
 public struct BookFormView: View {
-    @Binding var title: String
-    @Binding var author: String
-    @Binding var managementNumber: String
+    @Binding var book: Book
     let mode: BookFormMode
     let onSave: () -> Void
     let onCancel: () -> Void
     
     public init(
-        title: Binding<String>,
-        author: Binding<String>,
-        managementNumber: Binding<String>,
+        book: Binding<Book>,
         mode: BookFormMode,
         onSave: @escaping () -> Void,
         onCancel: @escaping () -> Void
     ) {
-        self._title = title
-        self._author = author
-        self._managementNumber = managementNumber
+        self._book = book
         self.mode = mode
         self.onSave = onSave
         self.onCancel = onCancel
@@ -31,10 +25,73 @@ public struct BookFormView: View {
     
     public var body: some View {
         Form {
-            Section(header: Text("絵本情報")) {
-                TextField("タイトル", text: $title)
-                TextField("著者", text: $author)
-                TextField("管理番号（例: あ13）", text: $managementNumber)
+            Section(header: Text("基本情報")) {
+                TextField("タイトル", text: $book.title)
+                TextField("著者", text: $book.author)
+                TextField(
+                    "管理番号（例: あ13）",
+                    text: Binding(
+                        get: { book.managementNumber ?? "" },
+                        set: { book.managementNumber = $0.isEmpty ? nil : $0 }
+                    ))
+            }
+            
+            Section(header: Text("詳細情報")) {
+                TextField(
+                    "ISBN-13",
+                    text: Binding(
+                        get: { book.isbn13 ?? "" },
+                        set: { book.isbn13 = $0.isEmpty ? nil : $0 }
+                    ))
+                TextField(
+                    "出版社",
+                    text: Binding(
+                        get: { book.publisher ?? "" },
+                        set: { book.publisher = $0.isEmpty ? nil : $0 }
+                    ))
+                TextField(
+                    "出版日",
+                    text: Binding(
+                        get: { book.publishedDate ?? "" },
+                        set: { book.publishedDate = $0.isEmpty ? nil : $0 }
+                    ))
+            }
+            
+            Section(header: Text("その他")) {
+                Stepper(
+                    "対象年齢: \(book.targetAge ?? 0)歳",
+                    value: Binding(
+                        get: { book.targetAge ?? 0 },
+                        set: { book.targetAge = $0 == 0 ? nil : $0 }
+                    ), in: 0...12)
+                
+                TextField(
+                    "ページ数",
+                    text: Binding(
+                        get: { book.pageCount.map(String.init) ?? "" },
+                        set: { newValue in
+                            if newValue.isEmpty {
+                                book.pageCount = nil
+                            } else if let intValue = Int(newValue), intValue >= 0 {
+                                book.pageCount = intValue
+                            }
+                        }
+                    )
+                )
+                #if os(iOS)
+                    .keyboardType(.numberPad)
+                #endif
+            }
+            
+            Section(header: Text("説明")) {
+                TextField(
+                    "絵本の説明・あらすじ",
+                    text: Binding(
+                        get: { book.description ?? "" },
+                        set: { book.description = $0.isEmpty ? nil : $0 }
+                    ), axis: .vertical
+                )
+                .lineLimit(3...6)
             }
         }
         .toolbar {
@@ -63,17 +120,28 @@ public struct BookFormView: View {
     }
     
     private var isValidInput: Bool {
-        !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-            && !author.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        !book.title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && !book.author.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 }
 
 #Preview {
+    @Previewable @State var sampleBook = Book(
+        title: "サンプル本",
+        author: "著者名",
+        isbn13: "9784001234567",
+        publisher: "サンプル出版",
+        publishedDate: "2023-01-01",
+        description: "これはサンプルの絵本です。",
+        targetAge: 3,
+        pageCount: 32,
+        categories: ["絵本"],
+        managementNumber: "あ13"
+    )
+    
     NavigationStack {
         BookFormView(
-            title: .constant("サンプル本"),
-            author: .constant("著者名"),
-            managementNumber: .constant("あ13"),
+            book: $sampleBook,
             mode: .add,
             onSave: {},
             onCancel: {}

--- a/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookSearchView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookSearchView.swift
@@ -394,11 +394,19 @@ struct SearchResultRow: View {
             searchError: nil,
             searchResults: [
                 ScoredBook(
-                    book: Book(title: "ぐりとぐら", author: "なかがわりえこ", targetAge: 3),
+                    book: Book(
+                        title: "ぐりとぐら",
+                        author: "なかがわりえこ",
+                        targetAge: 3
+                    ),
                     score: 0.95
                 ),
                 ScoredBook(
-                    book: Book(title: "ぐりとぐらのおきゃくさま", author: "なかがわりえこ", targetAge: 3),
+                    book: Book(
+                        title: "ぐりとぐらのおきゃくさま",
+                        author: "なかがわりえこ",
+                        targetAge: 3
+                    ),
                     score: 0.75
                 ),
             ],
@@ -431,7 +439,11 @@ struct SearchResultRow: View {
             selectedResult: nil,
             onResultSelected: { _ in },
             isManualEntryMode: true,
-            manualBook: Book(title: "テスタイトル", author: "テスト著者", targetAge: 4),
+            manualBook: Book(
+                title: "テスタイトル",
+                author: "テスト著者",
+                targetAge: 4
+            ),
             onManualBookChanged: { _ in },
             onSearch: {},
             onClearResults: {},

--- a/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookSearchView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookSearchView.swift
@@ -203,7 +203,8 @@ public struct BookSearchView: View {
                                         thumbnail: manualBook.thumbnail,
                                         targetAge: manualBook.targetAge,
                                         pageCount: manualBook.pageCount,
-                                        categories: manualBook.categories
+                                        categories: manualBook.categories,
+                                        managementNumber: manualBook.managementNumber
                                     )
                                     onManualBookChanged(updatedBook)
                                 }
@@ -232,7 +233,8 @@ public struct BookSearchView: View {
                                         thumbnail: manualBook.thumbnail,
                                         targetAge: manualBook.targetAge,
                                         pageCount: manualBook.pageCount,
-                                        categories: manualBook.categories
+                                        categories: manualBook.categories,
+                                        managementNumber: manualBook.managementNumber
                                     )
                                     onManualBookChanged(updatedBook)
                                 }
@@ -259,7 +261,8 @@ public struct BookSearchView: View {
                                 thumbnail: manualBook.thumbnail,
                                 targetAge: newAge,
                                 pageCount: manualBook.pageCount,
-                                categories: manualBook.categories
+                                categories: manualBook.categories,
+                                managementNumber: manualBook.managementNumber
                             )
                             onManualBookChanged(updatedBook)
                         }
@@ -397,7 +400,8 @@ struct SearchResultRow: View {
                     book: Book(
                         title: "ぐりとぐら",
                         author: "なかがわりえこ",
-                        targetAge: 3
+                        targetAge: 3,
+                        managementNumber: nil
                     ),
                     score: 0.95
                 ),
@@ -405,7 +409,8 @@ struct SearchResultRow: View {
                     book: Book(
                         title: "ぐりとぐらのおきゃくさま",
                         author: "なかがわりえこ",
-                        targetAge: 3
+                        targetAge: 3,
+                        managementNumber: nil
                     ),
                     score: 0.75
                 ),
@@ -442,7 +447,8 @@ struct SearchResultRow: View {
             manualBook: Book(
                 title: "テスタイトル",
                 author: "テスト著者",
-                targetAge: 4
+                targetAge: 4,
+                managementNumber: nil
             ),
             onManualBookChanged: { _ in },
             onSearch: {},

--- a/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Loan/LoanListView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Loan/LoanListView.swift
@@ -95,7 +95,7 @@ public struct LoanListView<RowAction: View>: View {
                 }
             }
         }
-        .listStyle(.grouped)
+        .listStyle(.sidebar)
     }
     
     private var sortedGroupNames: [String] {

--- a/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Views/LoanConfirmationView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Views/LoanConfirmationView.swift
@@ -130,7 +130,11 @@ private struct LoanInfoSection<Content: View>: View {
 
 #Preview {
     LoanConfirmationView(
-        book: Book(title: "はらぺこあおむし", author: "エリック・カール"),
+        book: Book(
+            title: "はらぺこあおむし",
+            author: "エリック・カール",
+            managementNumber: "あ13"
+        ),
         user: User(name: "山田太郎", classGroupId: UUID()),
         classGroup: ClassGroup(name: "ひよこ組", ageGroup: 0, year: 2025),
         dueDate: Date().addingTimeInterval(7 * 24 * 60 * 60),


### PR DESCRIPTION
## Summary
- 返却期限の自動計算機能を追加
- 絵本オブジェクトに管理番号フィールドを追加
- BookFormViewの改善（必須フィールド表示、プラットフォーム対応）
- 延滞バッジ表示機能を追加

## Changes

### 返却期限機能
- LoanSettingsで返却期限の自動計算に統一
- 返却期限が過ぎた場合にバッジを表示
- 貸出確認画面と詳細画面に返却期限を表示

### 絵本管理機能
- Bookオブジェクトに`managementNumber`フィールドを追加（例: "あ13"）
- BookFormViewで必須フィールドに視覚的指標(*)を追加
- セクション分けを改善（必須/任意の明確化）
- プラットフォーム別モーダル表示（iOS: fullScreenCover, macOS: sheet）

### UI/UX改善
- 返却確認アラートで利用者名と絵本情報を表示
- 延滞件数をタブバッジで表示
- 必須フィールドの視覚的改善

## Test plan
- [x] プロジェクト全体のビルドが成功すること
- [x] 全テストが通ること
- [x] 管理番号フィールドが正しく保存・表示されること
- [x] 返却期限計算が正しく動作すること
- [x] プラットフォーム別モーダル表示が動作すること

🤖 Generated with [Claude Code](https://claude.ai/code)