### PR TITLE
feat: 編集モードと保存ボタン機能の追加

### DIFF
--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/BookListContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/BookListContainerView.swift
@@ -83,6 +83,7 @@ struct BookListContainerView: View {
     _ = try? mockFactory.bookRepository.save(book2)
     
     let bookModel = BookModel(repository: mockFactory.bookRepository)
+    let userModel = UserModel(repository: mockFactory.userRepository)
     let loanModel = LoanModel(
         repository: mockFactory.loanRepository,
         bookRepository: mockFactory.bookRepository,
@@ -93,4 +94,5 @@ struct BookListContainerView: View {
     return BookListContainerView()
         .environment(bookModel)
         .environment(loanModel)
+        .environment(userModel)
 }

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/BookListContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/BookListContainerView.swift
@@ -43,7 +43,6 @@ struct BookListContainerView: View {
             LoanActionContainerButton(bookId: book.id)
         }
         .navigationTitle("絵本")
-        .searchable(text: $searchText, prompt: "タイトル・著者で検索")
         .toolbar {
             ToolbarItem(placement: .primaryAction) {
                 // 設定ボタン

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/BookListContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/BookListContainerView.swift
@@ -35,7 +35,10 @@ struct BookListContainerView: View {
         BookListView(
             books: filteredBooks,
             searchText: $searchText,
-            onDelete: handleDeleteBooks
+            isEditMode: false,
+            onSelect: handleSelectBook,
+            onEdit: { _ in },  // 編集モードオフなので使用されない
+            onDelete: { _ in }  // 編集モードオフなので削除不可
         ) { book in
             LoanActionContainerButton(bookId: book.id)
         }
@@ -65,15 +68,8 @@ struct BookListContainerView: View {
     
     // MARK: - Actions
     
-    private func handleDeleteBooks(at offsets: IndexSet) {
-        for index in offsets {
-            let book = filteredBooks[index]
-            do {
-                _ = try bookModel.deleteBook(book.id)
-            } catch {
-                alertState = .error("絵本の削除に失敗しました: \(error.localizedDescription)")
-            }
-        }
+    private func handleSelectBook(_ book: Book) {
+        // 絵本詳細画面に遷移（NavigationLinkで自動的に処理される）
     }
 }
 

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/SettingsBookListContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/SettingsBookListContainerView.swift
@@ -13,6 +13,8 @@ struct SettingsBookListContainerView: View {
     
     @State private var searchText = ""
     @State private var isAddSheetPresented = false
+    @State private var editingBook: Book?
+    @State private var isEditMode = false
     @State private var alertState = AlertState()
     
     private var filteredBooks: [Book] {
@@ -30,6 +32,9 @@ struct SettingsBookListContainerView: View {
         BookListView(
             books: filteredBooks,
             searchText: $searchText,
+            isEditMode: isEditMode,
+            onSelect: handleSelectBook,
+            onEdit: handleEditBook,
             onDelete: handleDeleteBooks
         ) { book in
             BookStatusView(isCurrentlyLent: loanModel.isBookLent(bookId: book.id))
@@ -39,6 +44,12 @@ struct SettingsBookListContainerView: View {
             BookDetailContainerView(book: book)
         }
         .toolbar {
+            ToolbarItem(placement: .navigation) {
+                Button(isEditMode ? "完了" : "編集") {
+                    isEditMode.toggle()
+                }
+            }
+            
             ToolbarItem(placement: .primaryAction) {
                 Button(action: {
                     isAddSheetPresented = true
@@ -56,12 +67,28 @@ struct SettingsBookListContainerView: View {
                     }
                 )
             }
+            .sheet(item: $editingBook) { book in
+                BookFormContainerView(
+                    mode: .edit(book),
+                    onSave: { _ in
+                        // 編集成功時にシートを閉じる処理は既にContainerView内で実行される
+                    }
+                )
+            }
         #else
             .fullScreenCover(isPresented: $isAddSheetPresented) {
                 BookFormContainerView(
                     mode: .add,
                     onSave: { _ in
                         // 追加成功時にシートを閉じる処理は既にContainerView内で実行される
+                    }
+                )
+            }
+            .fullScreenCover(item: $editingBook) { book in
+                BookFormContainerView(
+                    mode: .edit(book),
+                    onSave: { _ in
+                        // 編集成功時にシートを閉じる処理は既にContainerView内で実行される
                     }
                 )
             }
@@ -82,6 +109,14 @@ struct SettingsBookListContainerView: View {
     }
     
     // MARK: - Actions
+    
+    private func handleSelectBook(_ book: Book) {
+        // 絵本詳細画面に遷移（NavigationLinkで自動的に処理される）
+    }
+    
+    private func handleEditBook(_ book: Book) {
+        editingBook = book
+    }
     
     private func handleDeleteBooks(at offsets: IndexSet) {
         for index in offsets {

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/SettingsBookListContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/SettingsBookListContainerView.swift
@@ -44,11 +44,13 @@ struct SettingsBookListContainerView: View {
             BookDetailContainerView(book: book)
         }
         .toolbar {
-            ToolbarItem(placement: .navigation) {
-                Button(isEditMode ? "完了" : "編集") {
+            ToolbarItem {
+                Button(isEditMode ? "編集モード完了" : "編集モード") {
                     isEditMode.toggle()
                 }
             }
+            
+            ToolbarSpacer(.fixed)
             
             ToolbarItem(placement: .primaryAction) {
                 Button(action: {

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/User/UserDetailContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/User/UserDetailContainerView.swift
@@ -16,12 +16,12 @@ struct UserDetailContainerView: View {
     
     /// 利用者
     @State private var user: User
-    /// 編集表示
-    @State private var isEditSheetPresented = false
     /// 貸出数
     @State private var activeLoansCount = 0
     /// 貸出履歴
     @State private var loanHistory: [Loan] = []
+    /// アラート状態管理
+    @State private var alertState = AlertState()
     
     init(user: User) {
         self._user = State(initialValue: user)
@@ -37,9 +37,24 @@ struct UserDetailContainerView: View {
             loanHistory: loanHistory,
             getBookTitle: getBookTitle,
             getClassGroupName: getClassGroupName,
-            onEdit: handleEdit
+            onEdit: {}
         )
         .navigationTitle(user.name)
+        #if os(iOS)
+            .navigationBarTitleDisplayMode(.large)
+        #endif
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button("保存") {
+                    saveUserChanges(user)
+                }
+            }
+        }
+        .alert(alertState.title, isPresented: $alertState.isPresented) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(alertState.message)
+        }
         .onAppear {
             loadUserData()
         }
@@ -47,13 +62,13 @@ struct UserDetailContainerView: View {
     
     // MARK: - Actions
     
-    private func handleEdit() {
-        isEditSheetPresented = true
-    }
-    
-    private func handleUserSaved(_ savedUser: User) {
-        user = savedUser
-        loadUserData()
+    private func saveUserChanges(_ updatedUser: User) {
+        do {
+            _ = try userModel.updateUser(updatedUser)
+            alertState = .success("利用者情報を保存しました")
+        } catch {
+            alertState = .error("利用者情報の保存に失敗しました: \(error.localizedDescription)")
+        }
     }
     
     /// 絵本タイトル取得

--- a/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookListView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookListView.swift
@@ -62,7 +62,9 @@ public struct BookListView<RowAction: View>: View {
                 }
                 .onDelete(perform: isEditMode ? onDelete : nil)
             }
-            .searchable(text: searchText, prompt: "絵本のタイトルまたは著者で検索")
+            .searchable(
+                text: searchText, placement: .navigationBarDrawer(displayMode: .always),
+                prompt: "絵本のタイトルまたは著者で検索")
         }
     }
 }

--- a/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookListView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookListView.swift
@@ -9,17 +9,26 @@ import SwiftUI
 public struct BookListView<RowAction: View>: View {
     let books: [Book]
     let searchText: Binding<String>
+    let isEditMode: Bool
+    let onSelect: (Book) -> Void
+    let onEdit: (Book) -> Void
     let onDelete: (IndexSet) -> Void
     let rowAction: (Book) -> RowAction
     
     public init(
         books: [Book],
         searchText: Binding<String>,
+        isEditMode: Bool = false,
+        onSelect: @escaping (Book) -> Void,
+        onEdit: @escaping (Book) -> Void,
         onDelete: @escaping (IndexSet) -> Void,
         @ViewBuilder rowAction: @escaping (Book) -> RowAction
     ) {
         self.books = books
         self.searchText = searchText
+        self.isEditMode = isEditMode
+        self.onSelect = onSelect
+        self.onEdit = onEdit
         self.onDelete = onDelete
         self.rowAction = rowAction
     }
@@ -34,11 +43,24 @@ public struct BookListView<RowAction: View>: View {
         } else {
             List {
                 ForEach(books) { book in
-                    NavigationLink(value: book) {
-                        BookRowView(book: book, rowAction: rowAction)
+                    if isEditMode {
+                        Button {
+                            onEdit(book)
+                        } label: {
+                            BookRowView(book: book, rowAction: rowAction)
+                        }
+                        .buttonStyle(.plain)
+                    } else {
+                        NavigationLink(value: book) {
+                            BookRowView(book: book, rowAction: rowAction)
+                        }
+                        .simultaneousGesture(
+                            TapGesture().onEnded {
+                                onSelect(book)
+                            })
                     }
                 }
-                .onDelete(perform: onDelete)
+                .onDelete(perform: isEditMode ? onDelete : nil)
             }
             .searchable(text: searchText, prompt: "絵本のタイトルまたは著者で検索")
         }
@@ -91,6 +113,8 @@ public struct BookRowView<RowAction: View>: View {
         BookListView(
             books: [book1, book2],
             searchText: .constant(""),
+            onSelect: { _ in },
+            onEdit: { _ in },
             onDelete: { _ in }
         ) { book in
             LoanButtonView(onTap: {})


### PR DESCRIPTION
## Summary
- BookListViewにClassGroupListViewと同様の編集モード機能を追加
- UserDetailViewに手動保存ボタン機能を追加
- コード整理とリファクタリング

## Changes
### BookListView編集モード
- BookListContainerView: 編集モードOFF（削除不可）
- SettingsBookListContainerView: 編集モードON（削除可能）
- 編集モード時は選択/編集動作の切り替えに対応

### UserDetailView保存ボタン
- BookDetailViewと同様の右上保存ボタンを実装
- 手動保存時に成功/エラーアラートを表示
- 編集シート機能は不要のため削除

## Test plan
- [ ] BookListContainerViewで編集モードが無効であることを確認
- [ ] SettingsBookListContainerViewで編集モードが動作することを確認
- [ ] UserDetailViewの保存ボタンが動作することを確認
- [ ] 保存成功/エラー時のアラート表示を確認

🤖 Generated with [Claude Code](https://claude.ai/code)