### PR TITLE
絵本管理機能の大幅改善とターゲット読者選択の実装

### DIFF
--- a/PictureBookLendingAdminApp/.claude/settings.local.json
+++ b/PictureBookLendingAdminApp/.claude/settings.local.json
@@ -3,7 +3,8 @@
     "allow": [
       "Bash(xcodebuild:*)",
       "Bash(afplay:*)",
-      "Bash(git add:*)"
+      "Bash(git add:*)",
+      "Bash(git merge:*)"
     ],
     "deny": []
   }

--- a/PictureBookLendingAdminApp/PictureBookLendingDomain/Sources/PictureBookLendingDomain/Const.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingDomain/Sources/PictureBookLendingDomain/Const.swift
@@ -3,7 +3,27 @@ import Foundation
 /// アプリ全体で使用する定数定義
 public enum Const {
     
-    /// 年齢グループの定義
+    /// 絵本の対象読者の定義
+    public enum TargetAudience: String, CaseIterable, Codable, Sendable {
+        case infant = "乳児"
+        case toddler = "幼児"
+        case lowerElementary = "小学校低学年"
+        case upperElementary = "小学校高学年"
+        case juniorHighSchool = "中高生"
+        case adult = "大人"
+        
+        /// 表示用のテキスト
+        public var displayText: String {
+            return self.rawValue
+        }
+        
+        /// 順序付きの全ケース
+        public static var sortedCases: [TargetAudience] {
+            return allCases
+        }
+    }
+    
+    /// 年齢グループの定義（クラス分け用）
     public enum AgeGroup: String, CaseIterable, Sendable {
         case infant0 = "0歳児"
         case infant1 = "1歳児"

--- a/PictureBookLendingAdminApp/PictureBookLendingDomain/Sources/PictureBookLendingDomain/Domain/Book.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingDomain/Sources/PictureBookLendingDomain/Domain/Book.swift
@@ -21,8 +21,8 @@ public struct Book: Identifiable, Codable, Hashable, Sendable {
     public var smallThumbnail: String?
     /// 通常サイズのサムネイル画像のURL
     public var thumbnail: String?
-    /// 対象年齢
-    public var targetAge: Int?
+    /// 対象読者
+    public var targetAge: Const.TargetAudience?
     /// ページ数
     public var pageCount: Int?
     /// カテゴリ・ジャンル
@@ -55,7 +55,7 @@ public struct Book: Identifiable, Codable, Hashable, Sendable {
         description: String? = nil,
         smallThumbnail: String? = nil,
         thumbnail: String? = nil,
-        targetAge: Int? = nil,
+        targetAge: Const.TargetAudience? = nil,
         pageCount: Int? = nil,
         categories: [String] = [],
         managementNumber: String? = nil

--- a/PictureBookLendingAdminApp/PictureBookLendingDomain/Tests/PictureBookLendingDomainTests/Services/BookSearchScorerTests.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingDomain/Tests/PictureBookLendingDomainTests/Services/BookSearchScorerTests.swift
@@ -13,22 +13,22 @@ struct BookSearchScorerTests {
         Book(
             title: "ぐりとぐら",
             author: "なかがわりえこ",
-            targetAge: 3
+            targetAge: .toddler
         ),
         Book(
             title: "ぐりとぐらのおきゃくさま",
             author: "なかがわりえこ",
-            targetAge: 3
+            targetAge: .toddler
         ),
         Book(
             title: "はらぺこあおむし",
             author: "エリック・カール",
-            targetAge: 2
+            targetAge: .toddler
         ),
         Book(
             title: "スイミー",
             author: "レオ・レオニ",
-            targetAge: 4
+            targetAge: .lowerElementary
         ),
     ]
     
@@ -178,7 +178,7 @@ struct BookSearchScorerTests {
         let book = Book(
             title: "ABC Picture Book",
             author: "Test Author",
-            targetAge: 3
+            targetAge: .toddler
         )
         
         let query1 = BookSearchQuery(title: "abc picture book")
@@ -199,7 +199,7 @@ struct BookSearchScorerTests {
         let book = Book(
             title: "はらぺこあおむし",
             author: "エリック・カール",
-            targetAge: 2
+            targetAge: .toddler
         )
         
         // タイポを含むクエリ
@@ -232,7 +232,7 @@ struct ScoredBookTests {
         let book = Book(
             title: "Test Book",
             author: "Test Author",
-            targetAge: 3
+            targetAge: .toddler
         )
         
         let scoredBook1 = ScoredBook(book: book, score: 0.8)

--- a/PictureBookLendingAdminApp/PictureBookLendingInfrastructure/Sources/PictureBookLendingInfrastructure/Mocks/MockRepositories.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingInfrastructure/Sources/PictureBookLendingInfrastructure/Mocks/MockRepositories.swift
@@ -230,7 +230,7 @@ public final class MockBookSearchGateway: BookSearchGatewayProtocol {
             description: "これはテスト用の絵本です。",
             smallThumbnail: "https://example.com/small-thumbnail.jpg",
             thumbnail: "https://example.com/thumbnail.jpg",
-            targetAge: 3,
+            targetAge: .toddler,
             pageCount: 32,
             categories: ["絵本", "テスト"],
             managementNumber: "テスト\(isbn.suffix(3))"
@@ -252,7 +252,7 @@ public final class MockBookSearchGateway: BookSearchGatewayProtocol {
                 description: "これは\(title)のテスト用絵本です。",
                 smallThumbnail: "https://example.com/small-thumbnail\(i).jpg",
                 thumbnail: "https://example.com/thumbnail\(i).jpg",
-                targetAge: 2 + i,
+                targetAge: Const.TargetAudience.allCases[i % Const.TargetAudience.allCases.count],
                 pageCount: 30 + i * 2,
                 categories: ["絵本", "テスト"],
                 managementNumber: "テスト\(i)"

--- a/PictureBookLendingAdminApp/PictureBookLendingInfrastructure/Sources/PictureBookLendingInfrastructure/Repositories/SwiftDataBook.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingInfrastructure/Sources/PictureBookLendingInfrastructure/Repositories/SwiftDataBook.swift
@@ -41,8 +41,8 @@ final public class SwiftDataBook {
     /// 通常サイズのサムネイル画像のURL
     public var thumbnail: String?
     
-    /// 対象年齢
-    public var targetAge: Int?
+    /// 対象年齢（rawValue文字列として保存）
+    public var targetAge: String?
     
     /// ページ数
     public var pageCount: Int?
@@ -76,7 +76,7 @@ final public class SwiftDataBook {
         bookDescription: String? = nil,
         smallThumbnail: String? = nil,
         thumbnail: String? = nil,
-        targetAge: Int? = nil,
+        targetAge: String? = nil,
         pageCount: Int? = nil,
         categories: [String] = [],
         managementNumber: String? = nil

--- a/PictureBookLendingAdminApp/PictureBookLendingInfrastructure/Sources/PictureBookLendingInfrastructure/Repositories/SwiftDataBookRepository.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingInfrastructure/Sources/PictureBookLendingInfrastructure/Repositories/SwiftDataBookRepository.swift
@@ -32,7 +32,7 @@ public final class SwiftDataBookRepository: BookRepositoryProtocol, @unchecked S
             bookDescription: book.description,
             smallThumbnail: book.smallThumbnail,
             thumbnail: book.thumbnail,
-            targetAge: book.targetAge,
+            targetAge: book.targetAge?.rawValue,
             pageCount: book.pageCount,
             categories: book.categories,
             managementNumber: book.managementNumber
@@ -69,7 +69,9 @@ public final class SwiftDataBookRepository: BookRepositoryProtocol, @unchecked S
                     description: swiftDataBook.bookDescription,
                     smallThumbnail: swiftDataBook.smallThumbnail,
                     thumbnail: swiftDataBook.thumbnail,
-                    targetAge: swiftDataBook.targetAge,
+                    targetAge: swiftDataBook.targetAge.flatMap {
+                        Const.TargetAudience(rawValue: $0)
+                    },
                     pageCount: swiftDataBook.pageCount,
                     categories: swiftDataBook.categories,
                     managementNumber: swiftDataBook.managementNumber
@@ -105,7 +107,7 @@ public final class SwiftDataBookRepository: BookRepositoryProtocol, @unchecked S
                 description: swiftDataBook.bookDescription,
                 smallThumbnail: swiftDataBook.smallThumbnail,
                 thumbnail: swiftDataBook.thumbnail,
-                targetAge: swiftDataBook.targetAge,
+                targetAge: swiftDataBook.targetAge.flatMap { Const.TargetAudience(rawValue: $0) },
                 pageCount: swiftDataBook.pageCount,
                 categories: swiftDataBook.categories,
                 managementNumber: swiftDataBook.managementNumber
@@ -140,7 +142,7 @@ public final class SwiftDataBookRepository: BookRepositoryProtocol, @unchecked S
             swiftDataBook.bookDescription = book.description
             swiftDataBook.smallThumbnail = book.smallThumbnail
             swiftDataBook.thumbnail = book.thumbnail
-            swiftDataBook.targetAge = book.targetAge
+            swiftDataBook.targetAge = book.targetAge?.rawValue
             swiftDataBook.pageCount = book.pageCount
             swiftDataBook.categories = book.categories
             

--- a/PictureBookLendingAdminApp/PictureBookLendingModel/Sources/PictureBookLendingModel/RegisterModel.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingModel/Sources/PictureBookLendingModel/RegisterModel.swift
@@ -190,7 +190,7 @@ public class RegisterModel {
                 description: nil,
                 smallThumbnail: nil,
                 thumbnail: nil,
-                targetAge: 3,  // デフォルト対象年齢
+                targetAge: .toddler,  // デフォルト対象読者
                 pageCount: nil,
                 categories: [],
                 managementNumber: ""

--- a/PictureBookLendingAdminApp/PictureBookLendingModel/Tests/PictureBookLendingModelTests/RegisterModelTests.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingModel/Tests/PictureBookLendingModelTests/RegisterModelTests.swift
@@ -19,7 +19,7 @@ struct RegisterModelTests {
             description: "森で大きな卵を見つけたぐりとぐら...",
             smallThumbnail: nil,
             thumbnail: nil,
-            targetAge: 3,
+            targetAge: .toddler,
             pageCount: 28,
             categories: ["絵本", "児童書"]
         ),
@@ -32,7 +32,7 @@ struct RegisterModelTests {
             description: "雪の日にぐりとぐらが見つけた足跡...",
             smallThumbnail: nil,
             thumbnail: nil,
-            targetAge: 3,
+            targetAge: .toddler,
             pageCount: 28,
             categories: ["絵本", "児童書"]
         ),

--- a/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookFormView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookFormView.swift
@@ -58,12 +58,18 @@ public struct BookFormView: View {
             }
             
             Section(header: Text("その他（任意）")) {
-                Stepper(
-                    "対象年齢: \(book.targetAge ?? 0)歳",
-                    value: Binding(
-                        get: { book.targetAge ?? 0 },
-                        set: { book.targetAge = $0 == 0 ? nil : $0 }
-                    ), in: 0...12)
+                HStack {
+                    Text("対象読者")
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                    Picker("対象読者", selection: $book.targetAge) {
+                        Text("未選択").tag(nil as Const.TargetAudience?)
+                        ForEach(Const.TargetAudience.sortedCases, id: \.self) { audience in
+                            Text(audience.displayText).tag(audience as Const.TargetAudience?)
+                        }
+                    }
+                    .pickerStyle(.menu)
+                }
                 
                 TextField(
                     "ページ数",
@@ -133,7 +139,7 @@ public struct BookFormView: View {
         publisher: "サンプル出版",
         publishedDate: "2023-01-01",
         description: "これはサンプルの絵本です。",
-        targetAge: 3,
+        targetAge: .toddler,
         pageCount: 32,
         categories: ["絵本"],
         managementNumber: "あ13"

--- a/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookSearchView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookSearchView.swift
@@ -243,30 +243,41 @@ public struct BookSearchView: View {
                         .multilineTextAlignment(.trailing)
                     }
                     
-                    EditableDetailRowWithSelection(
-                        label: "対象年齢",
-                        selectedValue: .constant(manualBook.targetAge ?? 3),
-                        options: Array(1...10),
-                        displayText: { "\($0)歳" },
-                        onSelectionChanged: { newAge in
-                            let updatedBook = Book(
-                                id: manualBook.id,
-                                title: manualBook.title,
-                                author: manualBook.author,
-                                isbn13: manualBook.isbn13,
-                                publisher: manualBook.publisher,
-                                publishedDate: manualBook.publishedDate,
-                                description: manualBook.description,
-                                smallThumbnail: manualBook.smallThumbnail,
-                                thumbnail: manualBook.thumbnail,
-                                targetAge: newAge,
-                                pageCount: manualBook.pageCount,
-                                categories: manualBook.categories,
-                                managementNumber: manualBook.managementNumber
+                    HStack {
+                        Text("対象読者")
+                            .foregroundStyle(.secondary)
+                        Spacer()
+                        Picker(
+                            "対象読者",
+                            selection: Binding(
+                                get: { manualBook.targetAge },
+                                set: { newTargetAge in
+                                    let updatedBook = Book(
+                                        id: manualBook.id,
+                                        title: manualBook.title,
+                                        author: manualBook.author,
+                                        isbn13: manualBook.isbn13,
+                                        publisher: manualBook.publisher,
+                                        publishedDate: manualBook.publishedDate,
+                                        description: manualBook.description,
+                                        smallThumbnail: manualBook.smallThumbnail,
+                                        thumbnail: manualBook.thumbnail,
+                                        targetAge: newTargetAge,
+                                        pageCount: manualBook.pageCount,
+                                        categories: manualBook.categories,
+                                        managementNumber: manualBook.managementNumber
+                                    )
+                                    onManualBookChanged(updatedBook)
+                                }
                             )
-                            onManualBookChanged(updatedBook)
+                        ) {
+                            Text("未選択").tag(nil as Const.TargetAudience?)
+                            ForEach(Const.TargetAudience.sortedCases, id: \.self) { audience in
+                                Text(audience.displayText).tag(audience as Const.TargetAudience?)
+                            }
                         }
-                    )
+                        .pickerStyle(.menu)
+                    }
                 }
             }
         } else {
@@ -400,7 +411,7 @@ struct SearchResultRow: View {
                     book: Book(
                         title: "ぐりとぐら",
                         author: "なかがわりえこ",
-                        targetAge: 3,
+                        targetAge: .toddler,
                         managementNumber: nil
                     ),
                     score: 0.95
@@ -409,7 +420,7 @@ struct SearchResultRow: View {
                     book: Book(
                         title: "ぐりとぐらのおきゃくさま",
                         author: "なかがわりえこ",
-                        targetAge: 3,
+                        targetAge: .toddler,
                         managementNumber: nil
                     ),
                     score: 0.75
@@ -447,7 +458,7 @@ struct SearchResultRow: View {
             manualBook: Book(
                 title: "テスタイトル",
                 author: "テスト著者",
-                targetAge: 4,
+                targetAge: .lowerElementary,
                 managementNumber: nil
             ),
             onManualBookChanged: { _ in },


### PR DESCRIPTION
## Summary
- Bookオブジェクトに管理番号フィールドを追加（保育園固有の管理番号「あ13」等に対応）
- BookFormViewを@Binding var bookパターンにリファクタリングし、必須項目を*で明示
- ページ数入力をStepperからTextFieldに変更して数値入力を改善
- モーダル表示をfullScreenCoverに変更してスワイプでの誤操作を防止
- targetAgeをInt型からTargetAudience enum型に変更して対象読者選択を改善
- TargetAudienceとAgeGroupを概念分離してドメイン設計をクリーンアップ

## Test plan
- [x] 全モジュールのビルドが成功することを確認
- [x] 既存テストが全て通ることを確認
- [x] BookFormViewで管理番号、対象読者、ページ数が正しく入力できることを確認
- [x] モーダルがスワイプで閉じないことを確認
- [x] 必須項目に*が表示されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)