### PR TITLE
feat: BookDetailViewの表示情報充実と編集機能改善

### DIFF
--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/BookDetailContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/BookDetailContainerView.swift
@@ -13,7 +13,6 @@ struct BookDetailContainerView: View {
     @Environment(BookModel.self) private var bookModel
     
     @State private var book: Book
-    @State private var isEditSheetPresented = false
     @State private var alertState = AlertState()
     
     init(book: Book) {
@@ -25,7 +24,6 @@ struct BookDetailContainerView: View {
             book: $book,
             currentLoan: currentLoan,
             loanHistory: loanHistory,
-            onEdit: handleEdit
         ) {
             LoanActionContainerButton(bookId: book.id)
         }
@@ -33,13 +31,6 @@ struct BookDetailContainerView: View {
         #if os(iOS)
             .navigationBarTitleDisplayMode(.large)
         #endif
-        .toolbar {
-            ToolbarItem(placement: .primaryAction) {
-                Button("編集") {
-                    isEditSheetPresented = true
-                }
-            }
-        }
         .alert(alertState.title, isPresented: $alertState.isPresented) {
             Button("OK", role: .cancel) {}
         } message: {
@@ -61,16 +52,6 @@ struct BookDetailContainerView: View {
     private var loanHistory: [Loan] {
         loanModel.getLoansByBook(bookId: book.id)
             .sorted { $0.loanDate > $1.loanDate }  // 新しい順にソート
-    }
-    
-    // MARK: - Actions
-    
-    private func handleEdit() {
-        isEditSheetPresented = true
-    }
-    
-    private func handleBookSaved(_ savedBook: Book) {
-        book = savedBook
     }
 }
 

--- a/PictureBookLendingAdminApp/PictureBookLendingDomain/Sources/PictureBookLendingDomain/Domain/Book.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingDomain/Sources/PictureBookLendingDomain/Domain/Book.swift
@@ -27,7 +27,7 @@ public struct Book: Identifiable, Codable, Hashable, Sendable {
     public var pageCount: Int?
     /// カテゴリ・ジャンル
     public var categories: [String]
-    /// 独自の管理番号
+    /// 組織がすでに管理している独自の管理番号
     public var managementNumber: String?
     
     /// 絵本モデルの初期化（完全版）

--- a/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookDetailView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookDetailView.swift
@@ -13,8 +13,6 @@ public struct BookDetailView<ActionButton: View>: View {
     let currentLoan: Loan?
     /// 貸出履歴一覧
     let loanHistory: [Loan]
-    /// 編集ボタンタップ時のアクション
-    let onEdit: () -> Void
     /// 貸出・返却などのアクションボタンを生成するクロージャ
     let actionButton: () -> ActionButton
     
@@ -22,13 +20,11 @@ public struct BookDetailView<ActionButton: View>: View {
         book: Binding<Book>,
         currentLoan: Loan? = nil,
         loanHistory: [Loan] = [],
-        onEdit: @escaping () -> Void,
         @ViewBuilder actionButton: @escaping () -> ActionButton
     ) {
         self._book = book
         self.currentLoan = currentLoan
         self.loanHistory = loanHistory
-        self.onEdit = onEdit
         self.actionButton = actionButton
     }
     
@@ -58,10 +54,38 @@ public struct BookDetailView<ActionButton: View>: View {
             Section("基本情報") {
                 EditableDetailRow(label: "タイトル", value: $book.title)
                 EditableDetailRow(label: "著者", value: $book.author)
+                if let publisher = book.publisher, !publisher.isEmpty {
+                    DetailRow(label: "出版社", value: publisher)
+                }
+                if let publishedDate = book.publishedDate, !publishedDate.isEmpty {
+                    DetailRow(label: "出版日", value: publishedDate)
+                }
+                if let isbn13 = book.isbn13, !isbn13.isEmpty {
+                    DetailRow(label: "ISBN", value: isbn13)
+                }
+                if let pageCount = book.pageCount {
+                    DetailRow(label: "ページ数", value: "\(pageCount)ページ")
+                }
+                if let targetAge = book.targetAge {
+                    DetailRow(label: "対象年齢", value: "\(targetAge)歳以上")
+                }
+                if !book.categories.isEmpty {
+                    DetailRow(label: "カテゴリ", value: book.categories.joined(separator: ", "))
+                }
                 if let managementNumber = book.managementNumber, !managementNumber.isEmpty {
                     DetailRow(label: "管理番号", value: managementNumber)
+                } else {
+                    DetailRow(label: "管理番号", value: "未設定")
+                        .foregroundStyle(.secondary)
                 }
-                DetailRow(label: "管理ID", value: book.id.uuidString)
+            }
+            
+            if let description = book.description, !description.isEmpty {
+                Section("内容説明") {
+                    Text(description)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
             }
             
             Section("貸出状況") {
@@ -145,15 +169,22 @@ public struct BookDetailView<ActionButton: View>: View {
     @Previewable @State var sampleBook = Book(
         title: "はらぺこあおむし",
         author: "エリック・カール",
+        isbn13: "9784033280103",
+        publisher: "偕成社",
+        publishedDate: "1976-05-01",
+        description: "おなかがぺこぺこのあおむしが、美味しそうな食べ物をパクパク食べて成長していく物語。穴あきのしかけ絵本として世界中で愛されています。",
         smallThumbnail: "https://example.com/small-thumbnail.jpg",
-        thumbnail: "https://example.com/thumbnail.jpg"
+        thumbnail: "https://example.com/thumbnail.jpg",
+        targetAge: 3,
+        pageCount: 25,
+        categories: ["絵本", "しかけ絵本"],
+        managementNumber: "PB-001"
     )
     
     NavigationStack {
         BookDetailView(
             book: $sampleBook,
-            currentLoan: nil,
-            onEdit: {}
+            currentLoan: nil
         ) {
             Button("貸出") {}
                 .buttonStyle(.bordered)

--- a/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookListView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookListView.swift
@@ -63,7 +63,7 @@ public struct BookListView<RowAction: View>: View {
                 .onDelete(perform: isEditMode ? onDelete : nil)
             }
             .searchable(
-                text: searchText, placement: .navigationBarDrawer(displayMode: .always),
+                text: searchText,
                 prompt: "絵本のタイトルまたは著者で検索")
         }
     }


### PR DESCRIPTION
## Summary
- BookDetailViewの表示情報を大幅に充実
- 編集機能の整理とUI改善
- macOS互換性問題の修正

## Changes
### BookDetailViewの改善
- 詳細情報を追加：出版社、出版日、ISBN、ページ数、対象年齢、カテゴリ
- 内容説明セクションを新規追加
- 管理IDを管理番号に変更、未設定時は「未設定」と表示
- 借りている人の表示を削除（シンプル化）

### 編集機能の整理
- BookDetailContainerViewの編集ボタンとシート機能を削除
- UserDetailViewに保存ボタンを追加（BookDetailViewと統一）
- BookListViewとSettingsBookListContainerViewに編集モード機能を追加

### その他の修正
- macOS互換性問題を修正（searchable placement削除）
- コード整理とリファクタリング

## Test plan
- [ ] BookDetailViewで全ての情報が正しく表示されることを確認
- [ ] UserDetailViewの保存ボタンが動作することを確認
- [ ] BookListViewの編集モードが正しく動作することを確認
- [ ] macOSとiOSの両方でビルドが成功することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)