### PR TITLE
feat: 端末初期化機能と絵本カメラ撮影機能を実装

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,6 +256,7 @@ struct BookListContainerView: View {
 * `overlay` を優先し、`ZStack` は必要時のみ
 * 間隔調整は `spacing` を優先し、`padding` は必要最小限に
 * 命名は **Swift API Design Guidelines**／標準ライブラリに従う
+* **AnyViewは使用禁止**: 型消去が必要な場合はジェネリクスまたは@ViewBuilderを使用する
 * **マジックナンバーを使用しない**: 数値リテラルが意味を持つ場合はenum、定数、computed propertyで定義する
   * **画面固有の状態**: ContainerView内にprivate enumを定義
   * **ドメイン共通の定数**: Domainモジュールに定義  

--- a/PictureBookLendingAdminApp/.claude/settings.local.json
+++ b/PictureBookLendingAdminApp/.claude/settings.local.json
@@ -5,7 +5,9 @@
       "Bash(afplay:*)",
       "Bash(git add:*)",
       "Bash(git merge:*)",
-      "Bash(swift test)"
+      "Bash(swift test)",
+      "Bash(swift build)",
+      "Bash(swift:*)"
     ],
     "deny": []
   }

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin.xcodeproj/project.pbxproj
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin.xcodeproj/project.pbxproj
@@ -48,9 +48,22 @@
 		EFF77F0A2DD66AAD009BD213 /* PictureBookLendingAdminUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PictureBookLendingAdminUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		EFFB37302E4ED7E9001D68FC /* Exceptions for "PictureBookLendingAdmin" folder in "PictureBookLendingAdmin" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = EFF77EEF2DD66AAB009BD213 /* PictureBookLendingAdmin */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		EFF77EF22DD66AAB009BD213 /* PictureBookLendingAdmin */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				EFFB37302E4ED7E9001D68FC /* Exceptions for "PictureBookLendingAdmin" folder in "PictureBookLendingAdmin" target */,
+			);
 			path = PictureBookLendingAdmin;
 			sourceTree = "<group>";
 		};
@@ -477,6 +490,8 @@
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				ENABLE_USER_SELECTED_FILES = readonly;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = PictureBookLendingAdmin/Info.plist;
+				INFOPLIST_KEY_NSCameraUsageDescription = "絵本のサムネイル写真を撮影するためにカメラを使用しま";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
@@ -521,6 +536,8 @@
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				ENABLE_USER_SELECTED_FILES = readonly;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = PictureBookLendingAdmin/Info.plist;
+				INFOPLIST_KEY_NSCameraUsageDescription = "絵本のサムネイル写真を撮影するためにカメラを使用しま";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Info.plist
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Info.plist
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Models/BookSection.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Models/BookSection.swift
@@ -1,0 +1,48 @@
+import PictureBookLendingDomain
+
+/// 絵本リストのセクション分類
+/// 五十音順グループごとに絵本をセクション化するためのモデル
+struct AdminBookSection: Identifiable, Hashable {
+    let id: String
+    let kanaGroup: KanaGroup
+    let books: [Book]
+    
+    init(kanaGroup: KanaGroup, books: [Book]) {
+        self.id = kanaGroup.rawValue
+        self.kanaGroup = kanaGroup
+        self.books = books
+    }
+    
+    /// 表示用のセクションタイトル
+    var displayTitle: String {
+        kanaGroup.displayName
+    }
+    
+    /// セクションが空かどうか
+    var isEmpty: Bool {
+        books.isEmpty
+    }
+}
+
+extension AdminBookSection {
+    /// 絵本リストから五十音順セクションを作成
+    /// - Parameter books: 分類対象の絵本リスト
+    /// - Returns: 五十音順にソートされたセクションリスト
+    static func createSections(from books: [Book]) -> [AdminBookSection] {
+        // 五十音グループごとに絵本を分類
+        let groupedBooks = Dictionary(grouping: books) { book -> KanaGroup in
+            return book.kanaGroup ?? .other
+        }
+        
+        // セクションを作成し、五十音順にソート
+        let sections = groupedBooks.compactMap { (kanaGroup, books) in
+            AdminBookSection(kanaGroup: kanaGroup, books: books.sorted { $0.title < $1.title })
+        }
+        
+        // 五十音順にソート（空のセクションは除外）
+        return
+            sections
+            .filter { !$0.isEmpty }
+            .sorted { $0.kanaGroup.sortOrder < $1.kanaGroup.sortOrder }
+    }
+}

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/States/AlertState.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/States/AlertState.swift
@@ -13,6 +13,8 @@ struct AlertState {
         case success
         /// 確認ダイアログ
         case confirmation
+        /// 情報ダイアログ
+        case info
     }
     
     static func error(_ message: String) -> AlertState {
@@ -25,5 +27,9 @@ struct AlertState {
     
     static func confirmation(_ title: String, message: String) -> AlertState {
         AlertState(isPresented: true, title: title, message: message, type: .confirmation)
+    }
+    
+    static func info(_ message: String) -> AlertState {
+        AlertState(isPresented: true, title: "情報", message: message, type: .info)
     }
 }

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/BookAutoFillContainerButton.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/BookAutoFillContainerButton.swift
@@ -68,7 +68,7 @@ struct BookAutoFillContainerButton: View {
     private func handleSearch() {
         // BookFormViewのタイトルと著者名を使用して検索
         registerModel.searchTitle = targetBook.title
-        registerModel.searchAuthor = targetBook.author
+        registerModel.searchAuthor = targetBook.author ?? ""
         
         do {
             try registerModel.searchBooks()
@@ -82,7 +82,7 @@ struct BookAutoFillContainerButton: View {
         let updatedBook = Book(
             id: targetBook.id,  // 既存のIDを保持
             title: book.title.isEmpty ? targetBook.title : book.title,
-            author: book.author.isEmpty ? targetBook.author : book.author,
+            author: book.author?.isEmpty == false ? book.author : targetBook.author,
             isbn13: book.isbn13 ?? targetBook.isbn13,
             publisher: book.publisher ?? targetBook.publisher,
             publishedDate: book.publishedDate ?? targetBook.publishedDate,

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/BookBulkAddContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/BookBulkAddContainerView.swift
@@ -117,7 +117,8 @@ struct BookBulkAddContainerView: View {
             
             for entry in processedBooks {
                 if let book = entry.foundBook {
-                    // 管理番号を設定
+                    // 管理番号と五十音グループを設定
+                    let kanaGroup = KanaGroup.from(text: book.title)
                     let bookWithManagementNumber = Book(
                         id: book.id,
                         title: book.title,
@@ -131,7 +132,8 @@ struct BookBulkAddContainerView: View {
                         targetAge: book.targetAge,
                         pageCount: book.pageCount,
                         categories: book.categories,
-                        managementNumber: entry.managementNumber
+                        managementNumber: entry.managementNumber,
+                        kanaGroup: kanaGroup
                     )
                     
                     _ = try bookModel.registerBook(bookWithManagementNumber)

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/BookBulkAddContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/BookBulkAddContainerView.swift
@@ -1,0 +1,267 @@
+import PictureBookLendingDomain
+import PictureBookLendingInfrastructure
+import PictureBookLendingModel
+import PictureBookLendingUI
+import SwiftUI
+
+/// 絵本一括追加のContainer View
+struct BookBulkAddContainerView: View {
+    @Environment(BookModel.self) private var bookModel
+    @Environment(\.dismiss) private var dismiss
+    
+    @State private var inputText = ""
+    @State private var processedBooks: [ParsedBookEntry] = []
+    @State private var isProcessing = false
+    @State private var alertState = AlertState()
+    
+    // RegisterModelを使用して検索機能を利用
+    @State private var registerModel: RegisterModel
+    
+    init() {
+        // RegisterModelを初期化
+        let repositoryFactory = SwiftDataRepositoryFactory.shared
+        let gateway = repositoryFactory.makeBookSearchGateway()
+        let normalizer = GoogleBooksOptimizedNormalizer()
+        let repository = repositoryFactory.makeBookRepository()
+        
+        self._registerModel = State(
+            initialValue: RegisterModel(
+                gateway: gateway,
+                normalizer: normalizer,
+                repository: repository
+            )
+        )
+    }
+    
+    var body: some View {
+        BookBulkAddView(
+            inputText: $inputText,
+            processedBooks: processedBooks,
+            isProcessing: isProcessing,
+            onTextChange: handleTextChange,
+            onStartProcessing: handleStartProcessing,
+            onSave: handleSave,
+            onCancel: handleCancel
+        )
+        .alert(alertState.title, isPresented: $alertState.isPresented) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(alertState.message)
+        }
+    }
+    
+    // MARK: - Action Handlers
+    
+    private func handleTextChange(_ text: String) {
+        inputText = text
+        // テキストが変更されたら処理結果をクリア
+        if processedBooks.count > 0 {
+            processedBooks = []
+        }
+    }
+    
+    private func handleStartProcessing() {
+        Task {
+            await processBookEntries()
+        }
+    }
+    
+    private func handleSave() {
+        Task {
+            await saveBooksToModel()
+        }
+    }
+    
+    private func handleCancel() {
+        dismiss()
+    }
+    
+    // MARK: - Business Logic
+    
+    private func processBookEntries() async {
+        isProcessing = true
+        defer { isProcessing = false }
+        
+        do {
+            let parsedEntries = try parseInputText(inputText)
+            var processedEntries: [ParsedBookEntry] = []
+            
+            // 各エントリに対して検索を実行
+            for entry in parsedEntries {
+                var updatedEntry = entry
+                
+                // タイトルで検索を実行
+                await performSingleSearch(for: entry) { foundBook in
+                    if let book = foundBook {
+                        updatedEntry = ParsedBookEntry(
+                            managementNumber: entry.managementNumber,
+                            inputTitle: entry.inputTitle,
+                            foundBook: book
+                        )
+                    }
+                }
+                
+                processedEntries.append(updatedEntry)
+            }
+            
+            processedBooks = processedEntries
+            
+        } catch {
+            alertState = .error("テキスト解析でエラーが発生しました: \(error.localizedDescription)")
+        }
+    }
+    
+    private func saveBooksToModel() async {
+        do {
+            var savedCount = 0
+            
+            for entry in processedBooks {
+                if let book = entry.foundBook {
+                    // 管理番号を設定
+                    let bookWithManagementNumber = Book(
+                        id: book.id,
+                        title: book.title,
+                        author: book.author,
+                        isbn13: book.isbn13,
+                        publisher: book.publisher,
+                        publishedDate: book.publishedDate,
+                        description: book.description,
+                        smallThumbnail: book.smallThumbnail,
+                        thumbnail: book.thumbnail,
+                        targetAge: book.targetAge,
+                        pageCount: book.pageCount,
+                        categories: book.categories,
+                        managementNumber: entry.managementNumber
+                    )
+                    
+                    _ = try bookModel.registerBook(bookWithManagementNumber)
+                    savedCount += 1
+                }
+            }
+            
+            alertState = .info("\(savedCount)件の絵本を追加しました")
+            
+            // 成功したら画面を閉じる
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                dismiss()
+            }
+            
+        } catch {
+            alertState = .error("保存でエラーが発生しました: \(error.localizedDescription)")
+        }
+    }
+    
+    // MARK: - Search Logic
+    
+    private func performSingleSearch(
+        for entry: ParsedBookEntry, completion: @escaping (Book?) -> Void
+    ) async {
+        // RegisterModelに検索条件をセット
+        registerModel.searchTitle = entry.inputTitle
+        registerModel.searchAuthor = ""
+        registerModel.clearSearchResults()
+        
+        do {
+            try registerModel.searchBooks()
+            
+            // RegisterModelの状態変更を監視
+            await withCheckedContinuation { continuation in
+                var isCompleted = false
+                
+                // 検索状態の変化を監視するTask
+                let monitorTask = Task {
+                    let maxWaitTime = 10.0  // 最大待機時間を10秒に延長
+                    let startTime = Date()
+                    
+                    while !isCompleted && Date().timeIntervalSince(startTime) < maxWaitTime {
+                        if !registerModel.isSearching {
+                            // 検索完了
+                            if let bestMatch = findBestMatch(
+                                for: entry.inputTitle, in: registerModel.searchResults)
+                            {
+                                completion(bestMatch.book)
+                            } else {
+                                completion(nil)
+                            }
+                            isCompleted = true
+                            continuation.resume()
+                            return
+                        }
+                        
+                        try? await Task.sleep(nanoseconds: 100_000_000)  // 0.1秒待機
+                    }
+                    
+                    // タイムアウト
+                    if !isCompleted {
+                        print("Search timeout for: \(entry.inputTitle)")
+                        completion(nil)
+                        isCompleted = true
+                        continuation.resume()
+                    }
+                }
+                
+                // 初期状態で既に完了している場合の処理
+                if !registerModel.isSearching {
+                    monitorTask.cancel()
+                    if let bestMatch = findBestMatch(
+                        for: entry.inputTitle, in: registerModel.searchResults)
+                    {
+                        completion(bestMatch.book)
+                    } else {
+                        completion(nil)
+                    }
+                    isCompleted = true
+                    continuation.resume()
+                }
+            }
+            
+        } catch {
+            print("Search error for \(entry.inputTitle): \(error)")
+            completion(nil)
+        }
+    }
+    
+    // MARK: - Parsing Logic
+    
+    private func parseInputText(_ text: String) throws -> [ParsedBookEntry] {
+        let lines = text.components(separatedBy: .newlines)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        
+        var entries: [ParsedBookEntry] = []
+        
+        for line in lines {
+            let components = line.components(separatedBy: .whitespaces)
+                .filter { !$0.isEmpty }
+            
+            if components.count >= 2 {
+                let managementNumber = components[0]
+                let title = components[1...].joined(separator: " ")
+                
+                entries.append(
+                    ParsedBookEntry(
+                        managementNumber: managementNumber,
+                        inputTitle: title
+                    )
+                )
+            }
+        }
+        
+        return entries
+    }
+    
+    private func findBestMatch(for inputTitle: String, in results: [ScoredBook]) -> ScoredBook? {
+        // スコアが最も高い結果を返す（0.5以上のもののみ）
+        return
+            results
+            .filter { $0.score >= 0.5 }
+            .max(by: { $0.score < $1.score })
+    }
+}
+
+#Preview {
+    let mockFactory = MockRepositoryFactory()
+    
+    BookBulkAddContainerView()
+        .environment(BookModel(repository: mockFactory.bookRepository))
+}

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/BookBulkAddContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/BookBulkAddContainerView.swift
@@ -74,7 +74,9 @@ struct BookBulkAddContainerView: View {
                 .navigationTitle(
                     "絵本を追加 (\(failedBookItem.currentIndex + 1)/\(failedBookItem.totalCount))"
                 )
-                .navigationBarTitleDisplayMode(.inline)
+                #if !os(macOS)
+                    .navigationBarTitleDisplayMode(.inline)
+                #endif
                 .toolbar {
                     ToolbarItem(placement: .cancellationAction) {
                         Button("スキップ") {

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/BookFormContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/BookFormContainerView.swift
@@ -48,6 +48,9 @@ struct BookFormContainerView: View {
             )
             .navigationTitle(isEditMode ? "絵本を編集" : "絵本を追加")
             .interactiveDismissDisabled()
+            .onChange(of: book.title) { _, newTitle in
+                updateKanaGroup(for: newTitle)
+            }
             .alert(alertState.title, isPresented: $alertState.isPresented) {
                 Button("OK", role: .cancel) {}
             } message: {
@@ -111,6 +114,15 @@ struct BookFormContainerView: View {
     
     private func handleAutoFill(_ filledBook: Book) {
         book = filledBook
+        // 自動入力後も五十音分類を更新
+        updateKanaGroup(for: book.title)
+    }
+    
+    /// タイトルに基づいて五十音グループを自動設定
+    /// - Parameter title: 絵本のタイトル
+    private func updateKanaGroup(for title: String) {
+        let kanaGroup = KanaGroup.from(text: title)
+        book.kanaGroup = kanaGroup
     }
 }
 

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/BookFormContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/BookFormContainerView.swift
@@ -35,6 +35,12 @@ struct BookFormContainerView: View {
         }
     }
     
+    init(mode: BookFormMode, initialBook: Book, onSave: ((Book) -> Void)? = nil) {
+        self.mode = mode
+        self.onSave = onSave
+        self._book = State(initialValue: initialBook)
+    }
+    
     var body: some View {
         NavigationStack {
             BookFormView(

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/BookFormContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/BookFormContainerView.swift
@@ -20,6 +20,7 @@ struct BookFormContainerView: View {
     @State private var isConfirmationPresented = false
     @State private var isDuplicateConfirmationPresented = false
     @State private var duplicatedBook: Book?
+    @State private var isCameraPresented = false
     
     init(mode: BookFormMode, onSave: ((Book) -> Void)? = nil) {
         self.mode = mode
@@ -46,7 +47,8 @@ struct BookFormContainerView: View {
                     )
                 },
                 onSave: handleSave,
-                onCancel: handleCancel
+                onCancel: handleCancel,
+                onCameraTap: handleCameraTap
             )
             .navigationTitle(isEditMode ? "絵本を編集" : "絵本を追加")
             .interactiveDismissDisabled()
@@ -79,6 +81,14 @@ struct BookFormContainerView: View {
                 } else {
                     Text("この管理番号は既に使用されています。それでも保存しますか？")
                 }
+            }
+            .sheet(isPresented: $isCameraPresented) {
+                CameraImagePickerView(
+                    onImagePicked: handleImagePicked,
+                    onCancel: {
+                        isCameraPresented = false
+                    }
+                )
             }
         }
     }
@@ -158,6 +168,27 @@ struct BookFormContainerView: View {
     private func updateKanaGroup(for title: String) {
         let kanaGroup = KanaGroup.from(text: title)
         book.kanaGroup = kanaGroup
+    }
+    
+    /// カメラボタンタップ時の処理
+    private func handleCameraTap() {
+        isCameraPresented = true
+    }
+    
+    /// 撮影画像の処理
+    private func handleImagePicked(_ image: UIImage) {
+        isCameraPresented = false
+        
+        do {
+            // 画像をローカルに保存
+            let localPath = try ImageStorageUtility.saveImage(image)
+            
+            // Bookのthumbnailフィールドにローカルパスを設定
+            book.thumbnail = localPath
+            
+        } catch {
+            alertState = .error("画像の保存に失敗しました: \(error.localizedDescription)")
+        }
     }
 }
 

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/BookFormContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/BookFormContainerView.swift
@@ -4,6 +4,10 @@ import PictureBookLendingModel
 import PictureBookLendingUI
 import SwiftUI
 
+#if canImport(UIKit)
+    import UIKit
+#endif
+
 /// 絵本フォームのContainer View
 ///
 /// ビジネスロジック、状態管理、データ永続化を担当し、
@@ -88,14 +92,16 @@ struct BookFormContainerView: View {
                     Text("この管理番号は既に使用されています。それでも保存しますか？")
                 }
             }
-            .sheet(isPresented: $isCameraPresented) {
-                CameraImagePickerView(
-                    onImagePicked: handleImagePicked,
-                    onCancel: {
-                        isCameraPresented = false
-                    }
-                )
-            }
+            #if canImport(UIKit)
+                .sheet(isPresented: $isCameraPresented) {
+                    CameraImagePickerView(
+                        onImagePicked: handleImagePicked,
+                        onCancel: {
+                            isCameraPresented = false
+                        }
+                    )
+                }
+            #endif
         }
     }
     
@@ -182,20 +188,22 @@ struct BookFormContainerView: View {
     }
     
     /// 撮影画像の処理
-    private func handleImagePicked(_ image: UIImage) {
-        isCameraPresented = false
-        
-        do {
-            // 画像をローカルに保存
-            let localPath = try ImageStorageUtility.saveImage(image)
+    #if canImport(UIKit)
+        private func handleImagePicked(_ image: UIImage) {
+            isCameraPresented = false
             
-            // Bookのthumbnailフィールドにローカルパスを設定
-            book.thumbnail = localPath
-            
-        } catch {
-            alertState = .error("画像の保存に失敗しました: \(error.localizedDescription)")
+            do {
+                // 画像をローカルに保存
+                let localPath = try ImageStorageUtility.saveImage(image)
+                
+                // Bookのthumbnailフィールドにローカルパスを設定
+                book.thumbnail = localPath
+                
+            } catch {
+                alertState = .error("画像の保存に失敗しました: \(error.localizedDescription)")
+            }
         }
-    }
+    #endif
 }
 
 #Preview {

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/BookListContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/BookListContainerView.swift
@@ -29,7 +29,7 @@ struct BookListContainerView: View {
             } else {
                 allBooks.filter { book in
                     book.title.localizedCaseInsensitiveContains(searchText)
-                        || book.author.localizedCaseInsensitiveContains(searchText)
+                        || book.author?.localizedCaseInsensitiveContains(searchText) == true
                 }
             }
 

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/BookListContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/BookListContainerView.swift
@@ -16,6 +16,7 @@ struct BookListContainerView: View {
     @State private var isSettingsPresented = false
     @State private var alertState = AlertState()
     @State private var selectedKanaFilter: KanaGroup?
+    @State private var selectedSortType: BookSortType = .title
     
     private var filteredSections: [BookSection] {
         // 全絵本を表示（貸出可能・貸出中を含む）
@@ -37,9 +38,28 @@ struct BookListContainerView: View {
             return book.kanaGroup ?? .other
         }
         
-        // セクションを作成
+        // セクションを作成（ソート指定に基づいて）
         var sections = groupedBooks.compactMap { (kanaGroup, books) in
-            BookSection(kanaGroup: kanaGroup, books: books.sorted { $0.title < $1.title })
+            let sortedBooks: [Book]
+            switch selectedSortType {
+            case .title:
+                sortedBooks = books.sorted { $0.title < $1.title }
+            case .managementNumber:
+                sortedBooks = books.sorted { book1, book2 in
+                    // 管理番号がない場合は最後に配置
+                    switch (book1.managementNumber, book2.managementNumber) {
+                    case (nil, nil):
+                        return book1.title < book2.title
+                    case (nil, _):
+                        return false
+                    case (_, nil):
+                        return true
+                    case (let num1?, let num2?):
+                        return num1 < num2
+                    }
+                }
+            }
+            return BookSection(kanaGroup: kanaGroup, books: sortedBooks)
         }
         
         // 五十音順にソート
@@ -58,6 +78,7 @@ struct BookListContainerView: View {
             sections: filteredSections,
             searchText: $searchText,
             selectedKanaFilter: $selectedKanaFilter,
+            selectedSortType: $selectedSortType,
             isEditMode: false,
             onSelect: handleSelectBook,
             onEdit: { _ in },  // 編集モードオフなので使用されない

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/BookListContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/BookListContainerView.swift
@@ -15,6 +15,7 @@ struct BookListContainerView: View {
     @State private var searchText = ""
     @State private var isSettingsPresented = false
     @State private var alertState = AlertState()
+    @State private var useSectionView = false
     
     private var filteredBooks: [Book] {
         // 全絵本を表示（貸出可能・貸出中を含む）

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/BookListContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/BookListContainerView.swift
@@ -86,6 +86,16 @@ struct BookListContainerView: View {
         ) { book in
             LoanActionContainerButton(bookId: book.id)
         }
+        #if os(iOS)
+            .searchable(
+                text: $searchText,
+                placement: .navigationBarDrawer(displayMode: .always),
+                prompt: "絵本のタイトルまたは著者で検索")
+        #else
+            .searchable(
+                text: $searchText,
+                prompt: "絵本のタイトルまたは著者で検索")
+        #endif
         .navigationTitle("絵本")
         .toolbar {
             ToolbarItem(placement: .primaryAction) {

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/SettingsBookListContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/SettingsBookListContainerView.swift
@@ -59,7 +59,7 @@ struct SettingsBookListContainerView: View {
             isEditMode: isEditMode,
             onSelect: handleSelectBook,
             onEdit: handleEditBook,
-            onDelete: handleDeleteBooks
+            onDelete: handleDeleteBook
         ) { book in
             BookStatusView(isCurrentlyLent: loanModel.isBookLent(bookId: book.id))
         }
@@ -144,11 +144,12 @@ struct SettingsBookListContainerView: View {
         editingBook = book
     }
     
-    private func handleDeleteBooks(at offsets: IndexSet) {
-        // セクション内での削除処理はより複雑になるため、
-        // 現在は削除機能を無効化します
-        // TODO: セクション対応の削除処理を実装
-        alertState = .info("セクション表示では削除機能は現在無効です")
+    private func handleDeleteBook(_ book: Book) {
+        do {
+            _ = try bookModel.deleteBook(book.id)
+        } catch {
+            alertState = .error("絵本の削除に失敗しました: \(error.localizedDescription)")
+        }
     }
 }
 

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/SettingsBookListContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/SettingsBookListContainerView.swift
@@ -27,7 +27,7 @@ struct SettingsBookListContainerView: View {
             } else {
                 bookModel.books.filter { book in
                     book.title.localizedCaseInsensitiveContains(searchText)
-                        || book.author.localizedCaseInsensitiveContains(searchText)
+                        || book.author?.localizedCaseInsensitiveContains(searchText) == true
                 }
             }
 

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/SettingsBookListContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/SettingsBookListContainerView.swift
@@ -107,37 +107,17 @@ struct SettingsBookListContainerView: View {
         }
         #if os(macOS)
             .sheet(isPresented: $isAddSheetPresented) {
-                BookFormContainerView(
-                    mode: .add,
-                    onSave: { _ in
-                        // 追加成功時にシートを閉じる処理は既にContainerView内で実行される
-                    }
-                )
+                BookFormContainerView(mode: .add)
             }
             .sheet(item: $editingBook) { book in
-                BookFormContainerView(
-                    mode: .edit(book),
-                    onSave: { _ in
-                        // 編集成功時にシートを閉じる処理は既にContainerView内で実行される
-                    }
-                )
+                BookFormContainerView(mode: .edit(book))
             }
         #else
             .fullScreenCover(isPresented: $isAddSheetPresented) {
-                BookFormContainerView(
-                    mode: .add,
-                    onSave: { _ in
-                        // 追加成功時にシートを閉じる処理は既にContainerView内で実行される
-                    }
-                )
+                BookFormContainerView(mode: .add)
             }
             .fullScreenCover(item: $editingBook) { book in
-                BookFormContainerView(
-                    mode: .edit(book),
-                    onSave: { _ in
-                        // 編集成功時にシートを閉じる処理は既にContainerView内で実行される
-                    }
-                )
+                BookFormContainerView(mode: .edit(book))
             }
         #endif
         .alert(alertState.title, isPresented: $alertState.isPresented) {

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Loan/LoanActionContainerButton.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Loan/LoanActionContainerButton.swift
@@ -123,7 +123,7 @@ struct LoanActionContainerButton: View {
                 VStack(alignment: .leading) {
                     Text(sampleBook.title)
                         .font(.headline)
-                    Text(sampleBook.author)
+                    Text(sampleBook.author ?? "")
                         .font(.subheadline)
                         .foregroundStyle(.secondary)
                 }

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Loan/LoanFormContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Loan/LoanFormContainerView.swift
@@ -47,12 +47,22 @@ struct LoanFormContainerView: View {
                     }
                 }
                 
-                ToolbarItem(placement: .automatic) {
-                    Button("登録") {
-                        handleRegister()
+                #if os(iOS)
+                    ToolbarItem(placement: .bottomBar) {
+                        Button("登録") {
+                            handleRegister()
+                        }
+                        .tint(.accentColor)
+                        .disabled(!isValidInput)
                     }
-                    .disabled(!isValidInput)
-                }
+                #else
+                    ToolbarItem(placement: .confirmationAction) {
+                        Button("登録") {
+                            handleRegister()
+                        }
+                        .disabled(!isValidInput)
+                    }
+                #endif
             }
             .alert(alertState.title, isPresented: $alertState.isPresented) {
                 if alertState.type == .success {

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/SettingsContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/SettingsContainerView.swift
@@ -15,6 +15,7 @@ struct SettingsContainerView: View {
     
     @State private var navigationPath = NavigationPath()
     @State private var isLoanSettingsSheetPresented = false
+    @State private var isBulkAddSheetPresented = false
     
     var body: some View {
         NavigationStack(path: $navigationPath) {
@@ -29,6 +30,9 @@ struct SettingsContainerView: View {
                 },
                 onSelectBook: {
                     navigationPath.append(SettingsDestination.book)
+                },
+                onSelectBulkAdd: {
+                    isBulkAddSheetPresented = true
                 },
                 onSelectLoanSettings: {
                     isLoanSettingsSheetPresented = true
@@ -58,6 +62,9 @@ struct SettingsContainerView: View {
                 NavigationStack {
                     LoanSettingsContainerView()
                 }
+            }
+            .sheet(isPresented: $isBulkAddSheetPresented) {
+                BookBulkAddContainerView()
             }
         }
     }

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/SettingsContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/SettingsContainerView.swift
@@ -71,14 +71,17 @@ struct SettingsContainerView: View {
                 .sheet(isPresented: $isAddBookSheetPresented) {
                     BookFormContainerView(mode: .add)
                 }
+                .sheet(isPresented: $isBulkAddSheetPresented) {
+                    BookBulkAddContainerView()
+                }
             #else
                 .fullScreenCover(isPresented: $isAddBookSheetPresented) {
                     BookFormContainerView(mode: .add)
                 }
+                .fullScreenCover(isPresented: $isBulkAddSheetPresented) {
+                    BookBulkAddContainerView()
+                }
             #endif
-            .sheet(isPresented: $isBulkAddSheetPresented) {
-                BookBulkAddContainerView()
-            }
         }
     }
     

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/SettingsContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/SettingsContainerView.swift
@@ -15,6 +15,7 @@ struct SettingsContainerView: View {
     
     @State private var navigationPath = NavigationPath()
     @State private var isLoanSettingsSheetPresented = false
+    @State private var isAddBookSheetPresented = false
     @State private var isBulkAddSheetPresented = false
     
     var body: some View {
@@ -30,6 +31,9 @@ struct SettingsContainerView: View {
                 },
                 onSelectBook: {
                     navigationPath.append(SettingsDestination.book)
+                },
+                onSelectAddBook: {
+                    isAddBookSheetPresented = true
                 },
                 onSelectBulkAdd: {
                     isBulkAddSheetPresented = true
@@ -63,6 +67,15 @@ struct SettingsContainerView: View {
                     LoanSettingsContainerView()
                 }
             }
+            #if os(macOS)
+                .sheet(isPresented: $isAddBookSheetPresented) {
+                    BookFormContainerView(mode: .add)
+                }
+            #else
+                .fullScreenCover(isPresented: $isAddBookSheetPresented) {
+                    BookFormContainerView(mode: .add)
+                }
+            #endif
             .sheet(isPresented: $isBulkAddSheetPresented) {
                 BookBulkAddContainerView()
             }

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/SettingsContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/SettingsContainerView.swift
@@ -10,6 +10,7 @@ struct SettingsContainerView: View {
     @Environment(ClassGroupModel.self) private var classGroupModel
     @Environment(UserModel.self) private var userModel
     @Environment(BookModel.self) private var bookModel
+    @Environment(LoanModel.self) private var loanModel
     @Environment(LoanSettingsModel.self) private var loanSettingsModel
     @Environment(\.dismiss) private var dismiss
     
@@ -113,30 +114,27 @@ struct SettingsContainerView: View {
     
     private func performDeviceReset(_ options: DeviceResetOptions) async {
         do {
-            var deletedItems: [String] = []
+            var deletedDetails: [String] = []
             
             if options.deleteUsers {
-                // TODO: UserModelとClassGroupModelにdeleteAllメソッドを追加
-                // try await userModel.deleteAllUsers()
-                // try await classGroupModel.deleteAllClassGroups()
-                deletedItems.append("利用者データ")
+                let userCount = try userModel.deleteAllUsers()
+                let classGroupCount = try classGroupModel.deleteAllClassGroups()
+                deletedDetails.append("利用者データ(\(userCount)人)・クラス(\(classGroupCount)組)")
             }
             
             if options.deleteBooks {
-                // TODO: BookModelにdeleteAllBooksメソッドを追加
-                // try await bookModel.deleteAllBooks()
-                deletedItems.append("絵本データ")
+                let bookCount = try bookModel.deleteAllBooks()
+                deletedDetails.append("絵本データ(\(bookCount)冊)")
             }
             
             if options.deleteLoanRecords {
-                // TODO: LoanModelにdeleteAllLoansメソッドを追加
-                // try await loanModel.deleteAllLoans()
-                deletedItems.append("貸出記録")
+                let loanCount = try loanModel.deleteAllLoans()
+                deletedDetails.append("貸出記録(\(loanCount)件)")
             }
             
             let message =
-                if !deletedItems.isEmpty {
-                    "以下のデータを削除しました: \(deletedItems.joined(separator: "、"))"
+                if !deletedDetails.isEmpty {
+                    "以下のデータを削除しました:\n\(deletedDetails.joined(separator: "\n"))"
                 } else {
                     "削除するデータが選択されていません"
                 }

--- a/PictureBookLendingAdminApp/PictureBookLendingDomain/Sources/PictureBookLendingDomain/Domain/Book.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingDomain/Sources/PictureBookLendingDomain/Domain/Book.swift
@@ -8,7 +8,7 @@ public struct Book: Identifiable, Codable, Hashable, Sendable {
     /// 絵本のタイトル
     public var title: String
     /// 絵本の著者名
-    public var author: String
+    public var author: String?
     /// ISBN-13コード（13桁の数字文字列）
     public var isbn13: String?
     /// 出版社名
@@ -36,7 +36,7 @@ public struct Book: Identifiable, Codable, Hashable, Sendable {
     /// - Parameters:
     ///   - id: 絵本の一意識別子（デフォルトでは新しいUUIDが生成されます）
     ///   - title: 絵本のタイトル
-    ///   - author: 絵本の著者名
+    ///   - author: 絵本の著者名（任意）
     ///   - isbn13: ISBN-13コード（任意）
     ///   - publisher: 出版社名（任意）
     ///   - publishedDate: 出版日（任意）
@@ -51,7 +51,7 @@ public struct Book: Identifiable, Codable, Hashable, Sendable {
     public init(
         id: UUID = UUID(),
         title: String,
-        author: String,
+        author: String? = nil,
         isbn13: String? = nil,
         publisher: String? = nil,
         publishedDate: String? = nil,

--- a/PictureBookLendingAdminApp/PictureBookLendingDomain/Sources/PictureBookLendingDomain/Domain/Book.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingDomain/Sources/PictureBookLendingDomain/Domain/Book.swift
@@ -29,6 +29,8 @@ public struct Book: Identifiable, Codable, Hashable, Sendable {
     public var categories: [String]
     /// 組織がすでに管理している独自の管理番号
     public var managementNumber: String?
+    /// 五十音順グループ
+    public var kanaGroup: KanaGroup?
     
     /// 絵本モデルの初期化（完全版）
     /// - Parameters:
@@ -45,6 +47,7 @@ public struct Book: Identifiable, Codable, Hashable, Sendable {
     ///   - pageCount: ページ数（任意）
     ///   - categories: カテゴリ・ジャンル（デフォルトは空配列）
     ///   - managementNumber: 独自の管理番号（任意）
+    ///   - kanaGroup: 五十音順グループ（任意）
     public init(
         id: UUID = UUID(),
         title: String,
@@ -58,7 +61,8 @@ public struct Book: Identifiable, Codable, Hashable, Sendable {
         targetAge: Const.TargetAudience? = nil,
         pageCount: Int? = nil,
         categories: [String] = [],
-        managementNumber: String? = nil
+        managementNumber: String? = nil,
+        kanaGroup: KanaGroup? = nil
     ) {
         self.id = id
         self.title = title
@@ -73,26 +77,7 @@ public struct Book: Identifiable, Codable, Hashable, Sendable {
         self.targetAge = targetAge
         self.pageCount = pageCount
         self.categories = categories
+        self.kanaGroup = kanaGroup
     }
     
-    /// 絵本モデルの初期化（基本版・後方互換性のため）
-    /// - Parameters:
-    ///   - id: 絵本の一意識別子（デフォルトでは新しいUUIDが生成されます）
-    ///   - title: 絵本のタイトル
-    ///   - author: 絵本の著者名
-    public init(id: UUID = UUID(), title: String, author: String) {
-        self.id = id
-        self.title = title
-        self.author = author
-        self.isbn13 = nil
-        self.publisher = nil
-        self.publishedDate = nil
-        self.description = nil
-        self.smallThumbnail = nil
-        self.thumbnail = nil
-        self.targetAge = nil
-        self.pageCount = nil
-        self.categories = []
-        self.managementNumber = nil
-    }
 }

--- a/PictureBookLendingAdminApp/PictureBookLendingDomain/Sources/PictureBookLendingDomain/Domain/KanaGroup.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingDomain/Sources/PictureBookLendingDomain/Domain/KanaGroup.swift
@@ -1,0 +1,110 @@
+import Foundation
+
+/// 五十音順グループ
+/// 絵本のタイトルを五十音順で分類するためのグループ定義
+public enum KanaGroup: String, CaseIterable, Sendable, Codable {
+    case a = "あ"
+    case ka = "か"
+    case sa = "さ"
+    case ta = "た"
+    case na = "な"
+    case ha = "は"
+    case ma = "ま"
+    case ya = "や"
+    case ra = "ら"
+    case wa = "わ"
+    case other = "他"
+    
+    /// 表示用の名前
+    public var displayName: String {
+        rawValue
+    }
+    
+    /// 五十音グループの順序（並び替え用）
+    public var sortOrder: Int {
+        switch self {
+        case .a: return 0
+        case .ka: return 1
+        case .sa: return 2
+        case .ta: return 3
+        case .na: return 4
+        case .ha: return 5
+        case .ma: return 6
+        case .ya: return 7
+        case .ra: return 8
+        case .wa: return 9
+        case .other: return 10
+        }
+    }
+    
+    /// 五十音グループの文字範囲を定義
+    private static let groupRanges: [KanaGroup: [Character]] = [
+        .a: ["あ", "い", "う", "え", "お"],
+        .ka: ["か", "き", "く", "け", "こ", "が", "ぎ", "ぐ", "げ", "ご"],
+        .sa: ["さ", "し", "す", "せ", "そ", "ざ", "じ", "ず", "ぜ", "ぞ"],
+        .ta: ["た", "ち", "つ", "て", "と", "だ", "ぢ", "づ", "で", "ど"],
+        .na: ["な", "に", "ぬ", "ね", "の"],
+        .ha: ["は", "ひ", "ふ", "へ", "ほ", "ば", "び", "ぶ", "べ", "ぼ", "ぱ", "ぴ", "ぷ", "ぺ", "ぽ"],
+        .ma: ["ま", "み", "む", "め", "も"],
+        .ya: ["や", "ゆ", "よ"],
+        .ra: ["ら", "り", "る", "れ", "ろ"],
+        .wa: ["わ", "ゐ", "ゑ", "を", "ん"],
+    ]
+
+    /// 文字から五十音グループを取得
+    /// - Parameter character: 判定対象の文字
+    /// - Returns: 対応する五十音グループ、該当しない場合は.other
+    public static func from(character: Character) -> KanaGroup {
+        for (group, characters) in groupRanges {
+            if characters.contains(character) {
+                return group
+            }
+        }
+        return .other
+    }
+    
+    /// テキストから五十音グループを取得
+    /// - Parameter text: 判定対象のテキスト（絵本タイトルなど）
+    /// - Returns: 対応する五十音グループ、該当しない場合は.other
+    public static func from(text: String) -> KanaGroup {
+        // 空文字列の場合は.otherを返す
+        guard !text.isEmpty else { return .other }
+        
+        // テキストをひらがなに変換
+        let hiraganaText = text.toHiragana()
+        
+        // 最初の文字で判定
+        guard let firstCharacter = hiraganaText.first else { return .other }
+        
+        return from(character: firstCharacter)
+    }
+}
+
+/// 文字列の拡張 - 五十音分類用のユーティリティ
+extension String {
+    /// 文字列をひらがなに変換
+    /// 漢字、カタカナ、ローマ字をひらがなに変換する
+    /// - Returns: ひらがなに変換された文字列
+    public func toHiragana() -> String {
+        // CFStringTransformを使用してひらがなに変換
+        let mutableString = NSMutableString(string: self)
+        
+        // ローマ字 → ひらがな
+        CFStringTransform(mutableString, nil, kCFStringTransformLatinHiragana, false)
+        
+        // カタカナ → ひらがな
+        CFStringTransform(mutableString, nil, "Katakana-Hiragana" as CFString, false)
+        
+        // 漢字 → ひらがな（読み）
+        CFStringTransform(mutableString, nil, kCFStringTransformToLatin, false)
+        CFStringTransform(mutableString, nil, kCFStringTransformLatinHiragana, false)
+        
+        return mutableString as String
+    }
+    
+    /// 文字列から五十音グループを取得
+    /// - Returns: 対応する五十音グループ
+    public func kanaGroup() -> KanaGroup {
+        return KanaGroup.from(text: self)
+    }
+}

--- a/PictureBookLendingAdminApp/PictureBookLendingDomain/Sources/PictureBookLendingDomain/Services/BookSearchScorer.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingDomain/Sources/PictureBookLendingDomain/Services/BookSearchScorer.swift
@@ -48,11 +48,13 @@ public struct BookSearchScorer: Sendable {
         }
         
         // 著者マッチスコア（重み: 30%）
-        if let searchAuthor = searchQuery.author {
+        if let searchAuthor = searchQuery.author,
+            let bookAuthor = book.author
+        {
             let authorWeight = 0.3
             let authorScore = calculateAuthorMatchScore(
                 searchAuthor: searchAuthor,
-                bookAuthor: book.author
+                bookAuthor: bookAuthor
             )
             totalScore += authorScore * authorWeight
             totalWeight += authorWeight

--- a/PictureBookLendingAdminApp/PictureBookLendingInfrastructure/Sources/PictureBookLendingInfrastructure/Repositories/SwiftDataBook.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingInfrastructure/Sources/PictureBookLendingInfrastructure/Repositories/SwiftDataBook.swift
@@ -1,4 +1,5 @@
 import Foundation
+import PictureBookLendingDomain
 import SwiftData
 
 /// SwiftData用の絵本モデル
@@ -50,6 +51,9 @@ final public class SwiftDataBook {
     /// カテゴリ・ジャンルの配列
     public var categories: [String]
     
+    /// 五十音順グループ
+    public var kanaGroup: KanaGroup?
+    
     /// イニシャライザ
     ///
     /// - Parameters:
@@ -66,6 +70,7 @@ final public class SwiftDataBook {
     ///   - targetAge: 対象年齢
     ///   - pageCount: ページ数
     ///   - categories: カテゴリ・ジャンルの配列
+    ///   - kanaGroup: 五十音順グループ
     public init(
         id: UUID,
         title: String,
@@ -79,7 +84,8 @@ final public class SwiftDataBook {
         targetAge: String? = nil,
         pageCount: Int? = nil,
         categories: [String] = [],
-        managementNumber: String? = nil
+        managementNumber: String? = nil,
+        kanaGroup: KanaGroup? = nil
     ) {
         self.id = id
         self.title = title
@@ -94,5 +100,6 @@ final public class SwiftDataBook {
         self.targetAge = targetAge
         self.pageCount = pageCount
         self.categories = categories
+        self.kanaGroup = kanaGroup
     }
 }

--- a/PictureBookLendingAdminApp/PictureBookLendingInfrastructure/Sources/PictureBookLendingInfrastructure/Repositories/SwiftDataBook.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingInfrastructure/Sources/PictureBookLendingInfrastructure/Repositories/SwiftDataBook.swift
@@ -18,7 +18,7 @@ final public class SwiftDataBook {
     public var title: String
     
     /// 著者名
-    public var author: String
+    public var author: String?
     
     /// 独自の管理番号
     public var managementNumber: String?
@@ -59,7 +59,7 @@ final public class SwiftDataBook {
     /// - Parameters:
     ///   - id: 絵本の一意識別子
     ///   - title: 絵本のタイトル
-    ///   - author: 著者名
+    ///   - author: 著者名（任意）
     ///   - managementNumber: 独自の管理番号
     ///   - isbn13: ISBN-13コード
     ///   - publisher: 出版社名
@@ -74,7 +74,7 @@ final public class SwiftDataBook {
     public init(
         id: UUID,
         title: String,
-        author: String,
+        author: String? = nil,
         isbn13: String? = nil,
         publisher: String? = nil,
         publishedDate: String? = nil,

--- a/PictureBookLendingAdminApp/PictureBookLendingInfrastructure/Sources/PictureBookLendingInfrastructure/Repositories/SwiftDataBookRepository.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingInfrastructure/Sources/PictureBookLendingInfrastructure/Repositories/SwiftDataBookRepository.swift
@@ -35,7 +35,8 @@ public final class SwiftDataBookRepository: BookRepositoryProtocol, @unchecked S
             targetAge: book.targetAge?.rawValue,
             pageCount: book.pageCount,
             categories: book.categories,
-            managementNumber: book.managementNumber
+            managementNumber: book.managementNumber,
+            kanaGroup: book.kanaGroup
         )
         
         modelContext.insert(swiftDataBook)
@@ -74,7 +75,8 @@ public final class SwiftDataBookRepository: BookRepositoryProtocol, @unchecked S
                     },
                     pageCount: swiftDataBook.pageCount,
                     categories: swiftDataBook.categories,
-                    managementNumber: swiftDataBook.managementNumber
+                    managementNumber: swiftDataBook.managementNumber,
+                    kanaGroup: swiftDataBook.kanaGroup
                 )
             }
         } catch {
@@ -110,7 +112,8 @@ public final class SwiftDataBookRepository: BookRepositoryProtocol, @unchecked S
                 targetAge: swiftDataBook.targetAge.flatMap { Const.TargetAudience(rawValue: $0) },
                 pageCount: swiftDataBook.pageCount,
                 categories: swiftDataBook.categories,
-                managementNumber: swiftDataBook.managementNumber
+                managementNumber: swiftDataBook.managementNumber,
+                kanaGroup: swiftDataBook.kanaGroup
             )
         } catch {
             throw RepositoryError.fetchFailed
@@ -145,6 +148,7 @@ public final class SwiftDataBookRepository: BookRepositoryProtocol, @unchecked S
             swiftDataBook.targetAge = book.targetAge?.rawValue
             swiftDataBook.pageCount = book.pageCount
             swiftDataBook.categories = book.categories
+            swiftDataBook.kanaGroup = book.kanaGroup
             
             try modelContext.save()
             

--- a/PictureBookLendingAdminApp/PictureBookLendingInfrastructure/Sources/PictureBookLendingInfrastructure/Utilities/ImageStorageUtility.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingInfrastructure/Sources/PictureBookLendingInfrastructure/Utilities/ImageStorageUtility.swift
@@ -1,0 +1,120 @@
+import Foundation
+
+#if canImport(UIKit)
+    import UIKit
+#endif
+
+/// 画像のローカル保存・読み込みを管理するユーティリティ
+public enum ImageStorageUtility {
+    
+    #if canImport(UIKit)
+        
+        /// 画像保存用のディレクトリ名
+        private static let imageDirectoryName = "BookImages"
+        
+        /// 画像保存用ディレクトリのURL
+        private static var imageDirectoryURL: URL {
+            let documentsURL = FileManager.default.urls(
+                for: .documentDirectory, in: .userDomainMask
+            ).first!
+            return documentsURL.appendingPathComponent(imageDirectoryName)
+        }
+        
+        /// 画像保存用ディレクトリを作成
+        private static func createImageDirectoryIfNeeded() throws {
+            let imageDirectory = imageDirectoryURL
+            if !FileManager.default.fileExists(atPath: imageDirectory.path) {
+                try FileManager.default.createDirectory(
+                    at: imageDirectory,
+                    withIntermediateDirectories: true,
+                    attributes: nil
+                )
+            }
+        }
+        
+        /// 画像を保存してローカルパスを返す
+        /// - Parameters:
+        ///   - image: 保存する画像
+        ///   - fileName: ファイル名（拡張子なし、デフォルトでUUID生成）
+        /// - Returns: 保存されたファイルのローカルパス
+        /// - Throws: 保存に失敗した場合のエラー
+        public static func saveImage(_ image: UIImage, fileName: String = UUID().uuidString) throws
+            -> String
+        {
+            try createImageDirectoryIfNeeded()
+            
+            guard let imageData = image.jpegData(compressionQuality: 0.8) else {
+                throw ImageStorageError.imageCompressionFailed
+            }
+            
+            let fullFileName = "\(fileName).jpg"
+            let fileURL = imageDirectoryURL.appendingPathComponent(fullFileName)
+            
+            try imageData.write(to: fileURL)
+            
+            // ローカルパスを返す（file://スキームを含む）
+            return fileURL.absoluteString
+        }
+        
+        /// ローカルパスから画像を読み込む
+        /// - Parameter localPath: ローカルファイルパス
+        /// - Returns: 読み込まれた画像（失敗時はnil）
+        public static func loadImage(from localPath: String) -> UIImage? {
+            guard let url = URL(string: localPath) else { return nil }
+            
+            // file://スキームの場合はローカルファイル
+            if url.scheme == "file" {
+                return UIImage(contentsOfFile: url.path)
+            }
+            
+            // それ以外は従来のURL（リモート画像など）として扱う
+            return nil
+        }
+        
+        /// 指定されたローカルパスの画像ファイルを削除
+        /// - Parameter localPath: 削除するファイルのローカルパス
+        /// - Returns: 削除に成功した場合はtrue
+        public static func deleteImage(at localPath: String) -> Bool {
+            guard let url = URL(string: localPath),
+                url.scheme == "file"
+            else { return false }
+            
+            do {
+                try FileManager.default.removeItem(at: url)
+                return true
+            } catch {
+                print("画像削除に失敗: \(error)")
+                return false
+            }
+        }
+        
+        /// ローカル画像パスかどうかを判定
+        /// - Parameter path: 判定する文字列
+        /// - Returns: ローカル画像パスの場合はtrue
+        public static func isLocalImagePath(_ path: String?) -> Bool {
+            guard let path = path,
+                let url = URL(string: path)
+            else { return false }
+            return url.scheme == "file"
+        }
+
+    #endif
+}
+
+/// 画像保存関連のエラー
+public enum ImageStorageError: Error, LocalizedError {
+    case imageCompressionFailed
+    case fileNotFound
+    case saveLocationNotAvailable
+    
+    public var errorDescription: String? {
+        switch self {
+        case .imageCompressionFailed:
+            return "画像の圧縮に失敗しました"
+        case .fileNotFound:
+            return "画像ファイルが見つかりません"
+        case .saveLocationNotAvailable:
+            return "画像の保存場所にアクセスできません"
+        }
+    }
+}

--- a/PictureBookLendingAdminApp/PictureBookLendingModel/Sources/PictureBookLendingModel/BookModel.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingModel/Sources/PictureBookLendingModel/BookModel.swift
@@ -197,4 +197,28 @@ public class BookModel {
                 == managementNumber.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         }
     }
+    
+    /// 全ての絵本を削除する
+    ///
+    /// 全絵本データを削除します。端末初期化時に使用されます。
+    ///
+    /// - Returns: 削除された絵本の数
+    /// - Throws: 削除に失敗した場合は `BookModelError` を投げます
+    public func deleteAllBooks() throws -> Int {
+        do {
+            let currentBooks = books
+            
+            // 全ての絵本を削除
+            for book in currentBooks {
+                _ = try repository.delete(book.id)
+            }
+            
+            // キャッシュもクリア
+            books.removeAll()
+            
+            return currentBooks.count
+        } catch {
+            throw BookModelError.updateFailed
+        }
+    }
 }

--- a/PictureBookLendingAdminApp/PictureBookLendingModel/Sources/PictureBookLendingModel/ClassGroupModel.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingModel/Sources/PictureBookLendingModel/ClassGroupModel.swift
@@ -160,4 +160,28 @@ public class ClassGroupModel {
             print("クラスリストの更新に失敗しました: \(error)")
         }
     }
+    
+    /// 全てのクラスグループを削除する
+    ///
+    /// 全クラスグループデータを削除します。端末初期化時に使用されます。
+    ///
+    /// - Returns: 削除されたクラスグループの数
+    /// - Throws: 削除に失敗した場合は `ClassGroupModelError` を投げます
+    public func deleteAllClassGroups() throws -> Int {
+        do {
+            let currentClassGroups = classGroups
+            
+            // 全てのクラスグループを削除
+            for classGroup in currentClassGroups {
+                try repository.delete(by: classGroup.id)
+            }
+            
+            // キャッシュもクリア
+            classGroups.removeAll()
+            
+            return currentClassGroups.count
+        } catch {
+            throw ClassGroupModelError.deletionFailed
+        }
+    }
 }

--- a/PictureBookLendingAdminApp/PictureBookLendingModel/Sources/PictureBookLendingModel/LoanModel.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingModel/Sources/PictureBookLendingModel/LoanModel.swift
@@ -350,4 +350,28 @@ public class LoanModel {
             return loans.filter { $0.bookId == bookId }
         }
     }
+    
+    /// 全ての貸出記録を削除する
+    ///
+    /// 全貸出記録データを削除します。端末初期化時に使用されます。
+    ///
+    /// - Returns: 削除された貸出記録の数
+    /// - Throws: 削除に失敗した場合は `LoanModelError` を投げます
+    public func deleteAllLoans() throws -> Int {
+        do {
+            let currentLoans = loans
+            
+            // 全ての貸出記録を削除
+            for loan in currentLoans {
+                _ = try repository.delete(loan.id)
+            }
+            
+            // キャッシュもクリア
+            loans.removeAll()
+            
+            return currentLoans.count
+        } catch {
+            throw LoanModelError.returnFailed
+        }
+    }
 }

--- a/PictureBookLendingAdminApp/PictureBookLendingModel/Sources/PictureBookLendingModel/UserModel.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingModel/Sources/PictureBookLendingModel/UserModel.swift
@@ -169,4 +169,28 @@ public class UserModel {
             throw UserModelError.updateFailed
         }
     }
+    
+    /// 全ての利用者を削除する
+    ///
+    /// 全利用者データを削除します。端末初期化時に使用されます。
+    ///
+    /// - Returns: 削除された利用者の数
+    /// - Throws: 削除に失敗した場合は `UserModelError` を投げます
+    public func deleteAllUsers() throws -> Int {
+        do {
+            let currentUsers = users
+            
+            // 全ての利用者を削除
+            for user in currentUsers {
+                _ = try repository.delete(user.id)
+            }
+            
+            // キャッシュもクリア
+            users.removeAll()
+            
+            return currentUsers.count
+        } catch {
+            throw UserModelError.updateFailed
+        }
+    }
 }

--- a/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookBulkAddView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookBulkAddView.swift
@@ -148,7 +148,7 @@ struct BookBulkAddRowView: View {
                             .font(.caption)
                             .foregroundStyle(.green)
                         
-                        Text("著者: \(book.author)")
+                        Text("著者: \(book.author ?? "不明")")
                             .font(.caption2)
                             .foregroundStyle(.secondary)
                     }

--- a/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookBulkAddView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookBulkAddView.swift
@@ -10,6 +10,7 @@ public struct BookBulkAddView: View {
     let onStartProcessing: () -> Void
     let onSave: () -> Void
     let onCancel: () -> Void
+    let onRegisterFailed: ((ParsedBookEntry) -> Void)?
     
     public init(
         inputText: Binding<String>,
@@ -18,7 +19,8 @@ public struct BookBulkAddView: View {
         onTextChange: @escaping (String) -> Void,
         onStartProcessing: @escaping () -> Void,
         onSave: @escaping () -> Void,
-        onCancel: @escaping () -> Void
+        onCancel: @escaping () -> Void,
+        onRegisterFailed: ((ParsedBookEntry) -> Void)? = nil
     ) {
         self._inputText = inputText
         self.processedBooks = processedBooks
@@ -27,6 +29,7 @@ public struct BookBulkAddView: View {
         self.onStartProcessing = onStartProcessing
         self.onSave = onSave
         self.onCancel = onCancel
+        self.onRegisterFailed = onRegisterFailed
     }
     
     public var body: some View {
@@ -106,7 +109,10 @@ public struct BookBulkAddView: View {
             ScrollView {
                 LazyVStack(spacing: 8) {
                     ForEach(processedBooks, id: \.managementNumber) { entry in
-                        BookBulkAddRowView(entry: entry)
+                        BookBulkAddRowView(
+                            entry: entry,
+                            onRegisterFailed: onRegisterFailed
+                        )
                     }
                 }
             }
@@ -118,6 +124,7 @@ public struct BookBulkAddView: View {
 /// 一括追加の個別行表示
 struct BookBulkAddRowView: View {
     let entry: ParsedBookEntry
+    let onRegisterFailed: ((ParsedBookEntry) -> Void)?
     
     var body: some View {
         HStack {
@@ -153,6 +160,15 @@ struct BookBulkAddRowView: View {
             }
             
             Spacer()
+            
+            // 失敗した場合は個別登録ボタンを表示
+            if entry.foundBook == nil, let onRegisterFailed = onRegisterFailed {
+                Button("個別登録") {
+                    onRegisterFailed(entry)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+            }
             
             statusIcon
         }
@@ -215,6 +231,9 @@ public struct ParsedBookEntry: Identifiable {
         onTextChange: { _ in },
         onStartProcessing: {},
         onSave: {},
-        onCancel: {}
+        onCancel: {},
+        onRegisterFailed: { entry in
+            print("個別登録: \(entry.managementNumber) - \(entry.inputTitle)")
+        }
     )
 }

--- a/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookBulkAddView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookBulkAddView.swift
@@ -130,12 +130,7 @@ struct BookBulkAddRowView: View {
         HStack {
             VStack(alignment: .leading, spacing: 4) {
                 HStack {
-                    Text(entry.managementNumber)
-                        .font(.caption)
-                        .padding(.horizontal, 8)
-                        .padding(.vertical, 2)
-                        .background(.blue.opacity(0.1))
-                        .clipShape(RoundedRectangle(cornerRadius: 4))
+                    ManagementNumberBadge(text: entry.managementNumber)
                     
                     Text(entry.inputTitle)
                         .font(.subheadline)

--- a/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookBulkAddView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookBulkAddView.swift
@@ -1,0 +1,220 @@
+import PictureBookLendingDomain
+import SwiftUI
+
+/// 絵本一括追加のPresentation View
+public struct BookBulkAddView: View {
+    @Binding var inputText: String
+    let processedBooks: [ParsedBookEntry]
+    let isProcessing: Bool
+    let onTextChange: (String) -> Void
+    let onStartProcessing: () -> Void
+    let onSave: () -> Void
+    let onCancel: () -> Void
+    
+    public init(
+        inputText: Binding<String>,
+        processedBooks: [ParsedBookEntry],
+        isProcessing: Bool,
+        onTextChange: @escaping (String) -> Void,
+        onStartProcessing: @escaping () -> Void,
+        onSave: @escaping () -> Void,
+        onCancel: @escaping () -> Void
+    ) {
+        self._inputText = inputText
+        self.processedBooks = processedBooks
+        self.isProcessing = isProcessing
+        self.onTextChange = onTextChange
+        self.onStartProcessing = onStartProcessing
+        self.onSave = onSave
+        self.onCancel = onCancel
+    }
+    
+    public var body: some View {
+        NavigationStack {
+            VStack(spacing: 16) {
+                // 入力エリア
+                inputSection
+                
+                // 処理結果エリア
+                if !processedBooks.isEmpty {
+                    resultsSection
+                }
+                
+                Spacer()
+            }
+            .padding()
+            .navigationTitle("絵本一括追加")
+            #if os(iOS)
+                .navigationBarTitleDisplayMode(.large)
+            #endif
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("キャンセル") {
+                        onCancel()
+                    }
+                }
+                
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("保存") {
+                        onSave()
+                    }
+                    .disabled(processedBooks.isEmpty || isProcessing)
+                }
+            }
+        }
+    }
+    
+    private var inputSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("絵本データ入力")
+                .font(.headline)
+            
+            Text("管理番号とタイトルを以下の形式で入力してください：\n例: あ31 あいうえお")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            
+            TextEditor(text: $inputText)
+                .frame(minHeight: 120)
+                .padding(8)
+                .background(.regularMaterial)
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+                .onChange(of: inputText) { _, newValue in
+                    onTextChange(newValue)
+                }
+            
+            HStack {
+                Button("処理開始", systemImage: "play.fill") {
+                    onStartProcessing()
+                }
+                .disabled(
+                    inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                        || isProcessing)
+                
+                if isProcessing {
+                    ProgressView()
+                        .scaleEffect(0.8)
+                }
+            }
+        }
+    }
+    
+    private var resultsSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("処理結果 (\(processedBooks.count)件)")
+                .font(.headline)
+            
+            ScrollView {
+                LazyVStack(spacing: 8) {
+                    ForEach(processedBooks, id: \.managementNumber) { entry in
+                        BookBulkAddRowView(entry: entry)
+                    }
+                }
+            }
+            .frame(maxHeight: 300)
+        }
+    }
+}
+
+/// 一括追加の個別行表示
+struct BookBulkAddRowView: View {
+    let entry: ParsedBookEntry
+    
+    var body: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 4) {
+                HStack {
+                    Text(entry.managementNumber)
+                        .font(.caption)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 2)
+                        .background(.blue.opacity(0.1))
+                        .clipShape(RoundedRectangle(cornerRadius: 4))
+                    
+                    Text(entry.inputTitle)
+                        .font(.subheadline)
+                        .fontWeight(.medium)
+                }
+                
+                if let book = entry.foundBook {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("検索結果: \(book.title)")
+                            .font(.caption)
+                            .foregroundStyle(.green)
+                        
+                        Text("著者: \(book.author)")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                } else {
+                    Text("検索結果なし")
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                }
+            }
+            
+            Spacer()
+            
+            statusIcon
+        }
+        .padding(12)
+        .background(.regularMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+    }
+    
+    private var statusIcon: some View {
+        Image(
+            systemName: entry.foundBook != nil
+                ? "checkmark.circle.fill" : "exclamationmark.triangle.fill"
+        )
+        .foregroundStyle(entry.foundBook != nil ? .green : .orange)
+        .font(.title3)
+    }
+}
+
+/// パースされた絵本エントリ
+public struct ParsedBookEntry: Identifiable {
+    public let id = UUID()
+    public let managementNumber: String
+    public let inputTitle: String
+    public let foundBook: Book?
+    
+    public init(managementNumber: String, inputTitle: String, foundBook: Book? = nil) {
+        self.managementNumber = managementNumber
+        self.inputTitle = inputTitle
+        self.foundBook = foundBook
+    }
+}
+
+#Preview {
+    @Previewable @State var inputText = """
+        あ31 あいうえお
+        あ23 あいうえおうた
+        あ20 あいうえおおさま
+        """
+    
+    let sampleBooks = [
+        ParsedBookEntry(
+            managementNumber: "あ31",
+            inputTitle: "あいうえお",
+            foundBook: Book(
+                title: "あいうえお",
+                author: "いもとようこ"
+            )
+        ),
+        ParsedBookEntry(
+            managementNumber: "あ23",
+            inputTitle: "あいうえおうた",
+            foundBook: nil
+        ),
+    ]
+    
+    BookBulkAddView(
+        inputText: $inputText,
+        processedBooks: sampleBooks,
+        isProcessing: false,
+        onTextChange: { _ in },
+        onStartProcessing: {},
+        onSave: {},
+        onCancel: {}
+    )
+}

--- a/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookDetailView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookDetailView.swift
@@ -53,7 +53,13 @@ public struct BookDetailView<ActionButton: View>: View {
             
             Section("基本情報") {
                 EditableDetailRow(label: "タイトル", value: $book.title)
-                EditableDetailRow(label: "著者", value: $book.author)
+                EditableDetailRow(
+                    label: "著者",
+                    value: Binding(
+                        get: { book.author ?? "" },
+                        set: { book.author = $0.isEmpty ? nil : $0 }
+                    )
+                )
                 if let publisher = book.publisher, !publisher.isEmpty {
                     DetailRow(label: "出版社", value: publisher)
                 }

--- a/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookFormView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookFormView.swift
@@ -67,7 +67,13 @@ public struct BookFormView<AutoFillButton: View>: View {
             
             Section(header: Text("基本情報（*は必須）")) {
                 TextField("タイトル *", text: $book.title)
-                TextField("著者 *", text: $book.author)
+                TextField(
+                    "著者",
+                    text: Binding(
+                        get: { book.author ?? "" },
+                        set: { book.author = $0.isEmpty ? nil : $0 }
+                    )
+                )
                 
                 // 自動入力ボタン（タイトル・著者名の下に配置）
                 if let autoFillButton = autoFillButton {
@@ -187,7 +193,6 @@ public struct BookFormView<AutoFillButton: View>: View {
     
     private var isValidInput: Bool {
         !book.title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-            && !book.author.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
     
     @ViewBuilder

--- a/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookFormView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookFormView.swift
@@ -74,7 +74,7 @@ public struct BookFormView<AutoFillButton: View>: View {
                     HStack {
                         Image(systemName: "wand.and.stars")
                             .foregroundStyle(.secondary)
-                        Text("タイトルと著者名から情報を自動入力")
+                        Text("タイトルと著者名から情報を自動入力※実行回数には制限がございます。")
                             .font(.caption)
                             .foregroundStyle(.secondary)
                         Spacer()

--- a/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookFormView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookFormView.swift
@@ -114,18 +114,13 @@ public struct BookFormView<AutoFillButton: View>: View {
             }
             
             Section(header: Text("その他（任意）")) {
-                HStack {
-                    Text("対象読者")
-                        .foregroundStyle(.secondary)
-                    Spacer()
-                    Picker("対象読者", selection: $book.targetAge) {
-                        Text("未選択").tag(nil as Const.TargetAudience?)
-                        ForEach(Const.TargetAudience.sortedCases, id: \.self) { audience in
-                            Text(audience.displayText).tag(audience as Const.TargetAudience?)
-                        }
+                Picker("対象読者", selection: $book.targetAge) {
+                    Text("未選択").tag(nil as Const.TargetAudience?)
+                    ForEach(Const.TargetAudience.allCases, id: \.self) { audience in
+                        Text(audience.displayText).tag(audience as Const.TargetAudience?)
                     }
-                    .pickerStyle(.menu)
                 }
+                .pickerStyle(.menu)
                 
                 TextField(
                     "ページ数",
@@ -143,6 +138,15 @@ public struct BookFormView<AutoFillButton: View>: View {
                 #if os(iOS)
                     .keyboardType(.numberPad)
                 #endif
+                
+                Picker("ひらがなグループ", selection: $book.kanaGroup) {
+                    Text("未選択").tag(nil as KanaGroup?)
+                    ForEach(KanaGroup.allCases, id: \.self) { kana in
+                        Text(kana.displayName).tag(kana as KanaGroup?)
+                    }
+                }
+                .pickerStyle(.menu)
+                
             }
             
             Section(header: Text("説明（任意）")) {

--- a/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookImageView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookImageView.swift
@@ -1,0 +1,88 @@
+import Kingfisher
+import PictureBookLendingDomain
+import SwiftUI
+
+#if canImport(UIKit)
+    import UIKit
+#endif
+
+/// 絵本画像表示用のビュー
+/// ローカル画像とリモート画像の両方に対応
+public struct BookImageView<PlaceholderContent: View>: View {
+    let imageURL: String?
+    let placeholder: PlaceholderContent
+    
+    public init(
+        imageURL: String?,
+        @ViewBuilder placeholder: () -> PlaceholderContent
+    ) {
+        self.imageURL = imageURL
+        self.placeholder = placeholder()
+    }
+    
+    public var body: some View {
+        Group {
+            if let imageURL = imageURL {
+                if isLocalImagePath(imageURL) {
+                    // ローカル画像の表示
+                    #if canImport(UIKit)
+                        if let localImage = loadLocalImage(from: imageURL) {
+                            Image(uiImage: localImage)
+                                .resizable()
+                        } else {
+                            placeholder
+                        }
+                    #else
+                        placeholder
+                    #endif
+                } else {
+                    // リモート画像の表示（従来のKingfisher）
+                    KFImage(URL(string: imageURL))
+                        .placeholder {
+                            placeholder
+                        }
+                        .resizable()
+                }
+            } else {
+                placeholder
+            }
+        }
+    }
+    
+    /// ローカル画像パスかどうかを判定
+    private func isLocalImagePath(_ path: String) -> Bool {
+        guard let url = URL(string: path) else { return false }
+        return url.scheme == "file"
+    }
+    
+    /// ローカル画像を読み込む
+    #if canImport(UIKit)
+        private func loadLocalImage(from path: String) -> UIImage? {
+            guard let url = URL(string: path) else { return nil }
+            return UIImage(contentsOfFile: url.path)
+        }
+    #else
+        private func loadLocalImage(from path: String) -> NSImage? {
+            return nil
+        }
+    #endif
+}
+
+#Preview {
+    VStack {
+        // ローカル画像のプレビューは実際のファイルが必要なので、プレースホルダーを表示
+        BookImageView(imageURL: nil) {
+            Image(systemName: "book.closed")
+                .foregroundStyle(.secondary)
+                .font(.system(size: 40))
+        }
+        .frame(width: 100, height: 130)
+        .background(.regularMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+        
+        Text("画像プレビュー")
+            .font(.caption)
+            .foregroundStyle(.secondary)
+    }
+    .padding()
+}

--- a/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookListView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookListView.swift
@@ -259,14 +259,7 @@ public struct BookRowView<RowAction: View>: View {
                     .foregroundStyle(.secondary)
                 
                 if let managementNumber = book.managementNumber {
-                    Text("管理番号: \(managementNumber)")
-                        .font(.caption)
-                        .foregroundStyle(.primary)
-                        .padding(.horizontal, 6)
-                        .padding(.vertical, 2)
-                        .background(.blue.opacity(0.1))
-                        .foregroundStyle(.blue)
-                        .clipShape(.capsule)
+                    ManagementNumberBadge(text: managementNumber)
                 }
             }
             

--- a/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookListView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookListView.swift
@@ -199,9 +199,21 @@ public struct BookRowView<RowAction: View>: View {
             VStack(alignment: .leading, spacing: 4) {
                 Text(book.title)
                     .font(.headline)
+                
                 Text(book.author)
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
+                
+                if let managementNumber = book.managementNumber {
+                    Text("管理番号: \(managementNumber)")
+                        .font(.caption)
+                        .foregroundStyle(.primary)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(.blue.opacity(0.1))
+                        .foregroundStyle(.blue)
+                        .clipShape(.capsule)
+                }
             }
             
             Spacer()
@@ -216,8 +228,9 @@ public struct BookRowView<RowAction: View>: View {
     @Previewable @State var searchText = ""
     @Previewable @State var selectedKanaFilter: KanaGroup?
     
-    let book1 = Book(title: "はらぺこあおむし", author: "エリック・カール", kanaGroup: .ha)
-    let book2 = Book(title: "ぐりとぐら", author: "中川李枝子", kanaGroup: .ka)
+    let book1 = Book(
+        title: "はらぺこあおむし", author: "エリック・カール", managementNumber: "は001", kanaGroup: .ha)
+    let book2 = Book(title: "ぐりとぐら", author: "中川李枝子", managementNumber: "く002", kanaGroup: .ka)
     
     let sections = [
         BookSection(kanaGroup: .ka, books: [book2]),

--- a/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookListView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookListView.swift
@@ -206,16 +206,6 @@ public struct BookListView<RowAction: View>: View {
                 }
             }
         }
-        #if os(iOS)
-            .searchable(
-                text: $searchText,
-                placement: .navigationBarDrawer(displayMode: .always),
-                prompt: "絵本のタイトルまたは著者で検索")
-        #else
-            .searchable(
-                text: $searchText,
-                prompt: "絵本のタイトルまたは著者で検索")
-        #endif
     }
     
     /// 絵本行のコンテンツ

--- a/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookListView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookListView.swift
@@ -42,7 +42,7 @@ public struct BookListView<RowAction: View>: View {
     /// 絵本編集時の動作
     public let onEdit: (Book) -> Void
     /// 絵本削除時の動作
-    public let onDelete: (IndexSet) -> Void
+    public let onDelete: (Book) -> Void
     /// 各行に表示するアクションビューを生成するクロージャ
     public let rowAction: (Book) -> RowAction
     
@@ -55,7 +55,7 @@ public struct BookListView<RowAction: View>: View {
         isEditMode: Bool = false,
         onSelect: @escaping (Book) -> Void,
         onEdit: @escaping (Book) -> Void,
-        onDelete: @escaping (IndexSet) -> Void,
+        onDelete: @escaping (Book) -> Void,
         @ViewBuilder rowAction: @escaping (Book) -> RowAction
     ) {
         self.sections = sections
@@ -128,12 +128,15 @@ public struct BookListView<RowAction: View>: View {
                     ForEach(section.books) { book in
                         bookRowContent(for: book)
                     }
-                    .onDelete { indexSet in
-                        if isEditMode {
-                            // セクション内の削除処理は上位のContainerViewで処理
-                            onDelete(indexSet)
-                        }
-                    }
+                    .onDelete(
+                        perform: isEditMode
+                            ? { indexSet in
+                                // セクション内の削除処理
+                                for index in indexSet {
+                                    let book = section.books[index]
+                                    onDelete(book)
+                                }
+                            } : nil)
                 }
             }
         }
@@ -226,6 +229,7 @@ public struct BookRowView<RowAction: View>: View {
             sections: sections,
             searchText: $searchText,
             selectedKanaFilter: $selectedKanaFilter,
+            isEditMode: true,
             onSelect: { _ in },
             onEdit: { _ in },
             onDelete: { _ in }

--- a/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookListView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookListView.swift
@@ -266,7 +266,7 @@ public struct BookRowView<RowAction: View>: View {
                 Text(book.title)
                     .font(.headline)
                 
-                Text(book.author)
+                Text(book.author ?? "")
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
                 

--- a/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookListView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookListView.swift
@@ -240,17 +240,15 @@ public struct BookRowView<RowAction: View>: View {
     public var body: some View {
         HStack {
             // サムネイル画像
-            KFImage(URL(string: book.smallThumbnail ?? book.thumbnail ?? ""))
-                .placeholder {
-                    Image(systemName: "book.closed")
-                        .foregroundStyle(.secondary)
-                        .font(.title2)
-                }
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .frame(width: 50, height: 65)
-                .background(.regularMaterial)
-                .clipShape(RoundedRectangle(cornerRadius: 6))
+            BookImageView(imageURL: book.smallThumbnail ?? book.thumbnail) {
+                Image(systemName: "book.closed")
+                    .foregroundStyle(.secondary)
+                    .font(.title2)
+            }
+            .aspectRatio(contentMode: .fit)
+            .frame(width: 50, height: 65)
+            .background(.regularMaterial)
+            .clipShape(RoundedRectangle(cornerRadius: 6))
             
             VStack(alignment: .leading, spacing: 4) {
                 Text(book.title)

--- a/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookSearchResultsView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookSearchResultsView.swift
@@ -83,7 +83,7 @@ public struct BookSearchResultRowView: View {
                     .foregroundStyle(.primary)
                     .multilineTextAlignment(.leading)
                 
-                Text(scoredBook.book.author)
+                Text(scoredBook.book.author ?? "")
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
                 

--- a/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookSearchView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookSearchView.swift
@@ -219,12 +219,12 @@ public struct BookSearchView: View {
                         TextField(
                             "著者を入力",
                             text: Binding(
-                                get: { manualBook.author },
+                                get: { manualBook.author ?? "" },
                                 set: { newAuthor in
                                     let updatedBook = Book(
                                         id: manualBook.id,
                                         title: manualBook.title,
-                                        author: newAuthor,
+                                        author: newAuthor.isEmpty ? nil : newAuthor,
                                         isbn13: manualBook.isbn13,
                                         publisher: manualBook.publisher,
                                         publishedDate: manualBook.publishedDate,
@@ -347,7 +347,7 @@ struct SearchResultRow: View {
                         .foregroundStyle(.primary)
                         .multilineTextAlignment(.leading)
                     
-                    Text(scoredBook.book.author)
+                    Text(scoredBook.book.author ?? "")
                         .font(.subheadline)
                         .foregroundStyle(.secondary)
                     

--- a/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/CameraImagePickerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/CameraImagePickerView.swift
@@ -1,0 +1,87 @@
+import SwiftUI
+
+#if canImport(UIKit)
+    import UIKit
+    import AVFoundation
+#endif
+
+#if canImport(UIKit)
+    /// カメラ撮影用のImagePicker
+    /// UIImagePickerControllerをSwiftUIでラップして、カメラからの画像撮影機能を提供します
+    public struct CameraImagePickerView: UIViewControllerRepresentable {
+        public typealias UIViewControllerType = UIImagePickerController
+        
+        /// 撮影完了時のコールバック
+        public let onImagePicked: (UIImage) -> Void
+        /// キャンセル時のコールバック
+        public let onCancel: () -> Void
+        
+        public init(onImagePicked: @escaping (UIImage) -> Void, onCancel: @escaping () -> Void) {
+            self.onImagePicked = onImagePicked
+            self.onCancel = onCancel
+        }
+        
+        public func makeUIViewController(context: Context) -> UIImagePickerController {
+            let picker = UIImagePickerController()
+            picker.delegate = context.coordinator
+            picker.sourceType = .camera
+            picker.mediaTypes = ["public.image"]
+            picker.allowsEditing = true
+            return picker
+        }
+        
+        public func updateUIViewController(
+            _ uiViewController: UIImagePickerController, context: Context
+        ) {
+            // 更新処理は不要
+        }
+        
+        public func makeCoordinator() -> Coordinator {
+            Coordinator(self)
+        }
+        
+        public class Coordinator: NSObject, UIImagePickerControllerDelegate,
+            UINavigationControllerDelegate
+        {
+            let parent: CameraImagePickerView
+            
+            init(_ parent: CameraImagePickerView) {
+                self.parent = parent
+            }
+            
+            public func imagePickerController(
+                _ picker: UIImagePickerController,
+                didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]
+            ) {
+                if let editedImage = info[.editedImage] as? UIImage {
+                    parent.onImagePicked(editedImage)
+                } else if let originalImage = info[.originalImage] as? UIImage {
+                    parent.onImagePicked(originalImage)
+                }
+            }
+            
+            public func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
+                parent.onCancel()
+            }
+        }
+    }
+    
+    /// カメラ利用可能性チェック用のユーティリティ
+    @MainActor
+    public enum CameraUtility {
+        /// カメラが利用可能かどうかを確認
+        public static var isCameraAvailable: Bool {
+            UIImagePickerController.isSourceTypeAvailable(.camera)
+        }
+        
+        /// カメラ権限の状態を確認
+        public static var cameraAuthorizationStatus: AVAuthorizationStatus {
+            AVCaptureDevice.authorizationStatus(for: .video)
+        }
+        
+        /// カメラ権限をリクエスト
+        public static func requestCameraPermission(completion: @escaping (Bool) -> Void) {
+            AVCaptureDevice.requestAccess(for: .video, completionHandler: completion)
+        }
+    }
+#endif

--- a/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Loan/LoanFormView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Loan/LoanFormView.swift
@@ -41,7 +41,7 @@ public struct LoanFormView: View {
                         .font(.headline)
                         .foregroundStyle(.primary)
                     
-                    Text(book.author)
+                    Text(book.author ?? "")
                         .font(.subheadline)
                         .foregroundStyle(.secondary)
                 }

--- a/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Views/DeviceResetDialog.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Views/DeviceResetDialog.swift
@@ -29,7 +29,9 @@ public struct DeviceResetDialog: View {
             }
             .padding()
             .navigationTitle("端末初期化")
-            .navigationBarTitleDisplayMode(.inline)
+            #if !os(macOS)
+                .navigationBarTitleDisplayMode(.inline)
+            #endif
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("キャンセル") {

--- a/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Views/DeviceResetDialog.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Views/DeviceResetDialog.swift
@@ -1,0 +1,154 @@
+import SwiftUI
+
+/// 端末初期化選択ダイアログ
+public struct DeviceResetDialog: View {
+    @Binding var isPresented: Bool
+    @Binding var selectedOptions: DeviceResetOptions
+    let onConfirm: (DeviceResetOptions) -> Void
+    
+    public init(
+        isPresented: Binding<Bool>,
+        selectedOptions: Binding<DeviceResetOptions>,
+        onConfirm: @escaping (DeviceResetOptions) -> Void
+    ) {
+        self._isPresented = isPresented
+        self._selectedOptions = selectedOptions
+        self.onConfirm = onConfirm
+    }
+    
+    public var body: some View {
+        NavigationStack {
+            VStack(alignment: .leading, spacing: 20) {
+                // 警告メッセージ
+                warningSection
+                
+                // 削除オプション選択
+                optionsSection
+                
+                Spacer()
+            }
+            .padding()
+            .navigationTitle("端末初期化")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("キャンセル") {
+                        isPresented = false
+                    }
+                }
+                
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("削除実行") {
+                        onConfirm(selectedOptions)
+                        isPresented = false
+                    }
+                    .foregroundStyle(.red)
+                    .disabled(!selectedOptions.hasAnySelection)
+                }
+            }
+        }
+    }
+    
+    private var warningSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.orange)
+                Text("警告")
+                    .font(.headline)
+                    .foregroundStyle(.orange)
+            }
+            
+            Text("選択したデータは完全に削除され、復元できません。操作を実行する前に、必要なデータのバックアップを取ってください。")
+                .font(.body)
+                .foregroundStyle(.secondary)
+                .padding(.leading, 24)
+        }
+        .padding()
+        .background(.orange.opacity(0.1))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+    }
+    
+    private var optionsSection: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("削除するデータを選択してください")
+                .font(.headline)
+            
+            CheckboxRow(
+                isSelected: $selectedOptions.deleteUsers,
+                title: "利用者データ",
+                subtitle: "全ての利用者情報を削除"
+            )
+            
+            CheckboxRow(
+                isSelected: $selectedOptions.deleteBooks,
+                title: "絵本データ",
+                subtitle: "全ての絵本情報を削除"
+            )
+            
+            CheckboxRow(
+                isSelected: $selectedOptions.deleteLoanRecords,
+                title: "貸出記録",
+                subtitle: "全ての貸出・返却記録を削除"
+            )
+        }
+    }
+}
+
+/// チェックボックス付きの行
+private struct CheckboxRow: View {
+    @Binding var isSelected: Bool
+    let title: String
+    let subtitle: String
+    
+    var body: some View {
+        Button {
+            isSelected.toggle()
+        } label: {
+            HStack(spacing: 12) {
+                Image(systemName: isSelected ? "checkmark.square.fill" : "square")
+                    .font(.title3)
+                    .foregroundStyle(isSelected ? .blue : .gray)
+                
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(title)
+                        .font(.body)
+                        .foregroundStyle(.primary)
+                    Text(subtitle)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                
+                Spacer()
+            }
+            .padding(.vertical, 4)
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+/// 端末初期化のオプション
+public struct DeviceResetOptions {
+    public var deleteUsers: Bool = false
+    public var deleteBooks: Bool = false
+    public var deleteLoanRecords: Bool = false
+    
+    public var hasAnySelection: Bool {
+        deleteUsers || deleteBooks || deleteLoanRecords
+    }
+    
+    public init() {}
+}
+
+#Preview {
+    @Previewable @State var isPresented = true
+    @Previewable @State var options = DeviceResetOptions()
+    
+    DeviceResetDialog(
+        isPresented: $isPresented,
+        selectedOptions: $options,
+        onConfirm: { selectedOptions in
+            print("削除実行: \(selectedOptions)")
+        }
+    )
+}

--- a/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Views/LoanConfirmationView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Views/LoanConfirmationView.swift
@@ -42,7 +42,7 @@ public struct LoanConfirmationView: View {
                         VStack(alignment: .leading, spacing: 4) {
                             Text(book.title)
                                 .font(.headline)
-                            Text("著者: \(book.author)")
+                            Text("著者: \(book.author ?? "不明")")
                                 .font(.caption)
                                 .foregroundStyle(.secondary)
                         }

--- a/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Views/ManagementNumberBadge.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Views/ManagementNumberBadge.swift
@@ -1,0 +1,60 @@
+import SwiftUI
+
+/// 管理番号表示用のバッジコンポーネント
+/// BookListViewとBookBulkAddViewで統一されたUIを提供
+public struct ManagementNumberBadge: View {
+    let text: String
+    let style: Style
+    
+    public enum Style {
+        case primary  // 通常の青色
+        case success  // 成功時の緑色
+        case secondary  // セカンダリ色
+        
+        var backgroundColor: Color {
+            switch self {
+            case .primary:
+                return .blue.opacity(0.1)
+            case .success:
+                return .green.opacity(0.1)
+            case .secondary:
+                return .gray.opacity(0.1)
+            }
+        }
+        
+        var foregroundColor: Color {
+            switch self {
+            case .primary:
+                return .blue
+            case .success:
+                return .green
+            case .secondary:
+                return .secondary
+            }
+        }
+    }
+    
+    public init(text: String, style: Style = .primary) {
+        self.text = text
+        self.style = style
+    }
+    
+    public var body: some View {
+        Text(text)
+            .font(.caption)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 2)
+            .background(style.backgroundColor)
+            .foregroundStyle(style.foregroundColor)
+            .clipShape(RoundedRectangle(cornerRadius: 4))
+    }
+}
+
+#Preview {
+    VStack(spacing: 8) {
+        ManagementNumberBadge(text: "あ001", style: .primary)
+        ManagementNumberBadge(text: "か123", style: .success)
+        ManagementNumberBadge(text: "さ456", style: .secondary)
+    }
+    .padding()
+}

--- a/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Views/SettingsView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Views/SettingsView.swift
@@ -15,6 +15,7 @@ public struct SettingsView: View {
     let onSelectAddBook: () -> Void
     let onSelectBulkAdd: () -> Void
     let onSelectLoanSettings: () -> Void
+    let onSelectDeviceReset: () -> Void
     
     public init(
         classGroupCount: Int,
@@ -26,7 +27,8 @@ public struct SettingsView: View {
         onSelectBook: @escaping () -> Void,
         onSelectAddBook: @escaping () -> Void,
         onSelectBulkAdd: @escaping () -> Void,
-        onSelectLoanSettings: @escaping () -> Void
+        onSelectLoanSettings: @escaping () -> Void,
+        onSelectDeviceReset: @escaping () -> Void
     ) {
         self.classGroupCount = classGroupCount
         self.userCount = userCount
@@ -38,6 +40,7 @@ public struct SettingsView: View {
         self.onSelectAddBook = onSelectAddBook
         self.onSelectBulkAdd = onSelectBulkAdd
         self.onSelectLoanSettings = onSelectLoanSettings
+        self.onSelectDeviceReset = onSelectDeviceReset
     }
     
     public var body: some View {
@@ -77,6 +80,17 @@ public struct SettingsView: View {
                 action: onSelectLoanSettings
             )
             
+            Divider()
+                .padding(.vertical, 8)
+            
+            SettingsMenuItem(
+                iconName: "trash.circle",
+                title: "端末初期化",
+                subtitle: "利用者・絵本・貸出記録のデータを削除",
+                action: onSelectDeviceReset,
+                style: .destructive
+            )
+            
             Spacer()
         }
         .padding()
@@ -90,6 +104,37 @@ private struct SettingsMenuItem: View {
     let title: String
     let subtitle: String
     let action: () -> Void
+    let style: Style
+    
+    enum Style {
+        case normal
+        case destructive
+        
+        var iconColor: Color {
+            switch self {
+            case .normal: return .primary
+            case .destructive: return .red
+            }
+        }
+        
+        var titleColor: Color {
+            switch self {
+            case .normal: return .primary
+            case .destructive: return .red
+            }
+        }
+    }
+    
+    init(
+        iconName: String, title: String, subtitle: String, action: @escaping () -> Void,
+        style: Style = .normal
+    ) {
+        self.iconName = iconName
+        self.title = title
+        self.subtitle = subtitle
+        self.action = action
+        self.style = style
+    }
     
     var body: some View {
         Button(action: action) {
@@ -97,9 +142,11 @@ private struct SettingsMenuItem: View {
                 Image(systemName: iconName)
                     .font(.title2)
                     .frame(width: 30)
+                    .foregroundStyle(style.iconColor)
                 VStack(alignment: .leading, spacing: 2) {
                     Text(title)
                         .font(.headline)
+                        .foregroundStyle(style.titleColor)
                     Text(subtitle)
                         .font(.caption)
                         .foregroundStyle(.secondary)
@@ -129,7 +176,8 @@ private struct SettingsMenuItem: View {
             onSelectBook: {},
             onSelectAddBook: {},
             onSelectBulkAdd: {},
-            onSelectLoanSettings: {}
+            onSelectLoanSettings: {},
+            onSelectDeviceReset: {}
         )
         .navigationTitle("設定")
     }

--- a/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Views/SettingsView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Views/SettingsView.swift
@@ -12,6 +12,7 @@ public struct SettingsView: View {
     let maxBooksPerUser: Int
     let onSelectUser: () -> Void
     let onSelectBook: () -> Void
+    let onSelectBulkAdd: () -> Void
     let onSelectLoanSettings: () -> Void
     
     public init(
@@ -22,6 +23,7 @@ public struct SettingsView: View {
         maxBooksPerUser: Int,
         onSelectUser: @escaping () -> Void,
         onSelectBook: @escaping () -> Void,
+        onSelectBulkAdd: @escaping () -> Void,
         onSelectLoanSettings: @escaping () -> Void
     ) {
         self.classGroupCount = classGroupCount
@@ -31,6 +33,7 @@ public struct SettingsView: View {
         self.maxBooksPerUser = maxBooksPerUser
         self.onSelectUser = onSelectUser
         self.onSelectBook = onSelectBook
+        self.onSelectBulkAdd = onSelectBulkAdd
         self.onSelectLoanSettings = onSelectLoanSettings
     }
     
@@ -48,6 +51,13 @@ public struct SettingsView: View {
                 title: "絵本管理",
                 subtitle: "\(bookCount)冊登録済み",
                 action: onSelectBook
+            )
+            
+            SettingsMenuItem(
+                iconName: "plus.rectangle.on.rectangle",
+                title: "絵本一括追加",
+                subtitle: "テキストから複数の絵本を一度に登録",
+                action: onSelectBulkAdd
             )
             
             SettingsMenuItem(
@@ -107,6 +117,7 @@ private struct SettingsMenuItem: View {
             maxBooksPerUser: 1,
             onSelectUser: {},
             onSelectBook: {},
+            onSelectBulkAdd: {},
             onSelectLoanSettings: {}
         )
         .navigationTitle("設定")

--- a/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Views/SettingsView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Views/SettingsView.swift
@@ -12,6 +12,7 @@ public struct SettingsView: View {
     let maxBooksPerUser: Int
     let onSelectUser: () -> Void
     let onSelectBook: () -> Void
+    let onSelectAddBook: () -> Void
     let onSelectBulkAdd: () -> Void
     let onSelectLoanSettings: () -> Void
     
@@ -23,6 +24,7 @@ public struct SettingsView: View {
         maxBooksPerUser: Int,
         onSelectUser: @escaping () -> Void,
         onSelectBook: @escaping () -> Void,
+        onSelectAddBook: @escaping () -> Void,
         onSelectBulkAdd: @escaping () -> Void,
         onSelectLoanSettings: @escaping () -> Void
     ) {
@@ -33,6 +35,7 @@ public struct SettingsView: View {
         self.maxBooksPerUser = maxBooksPerUser
         self.onSelectUser = onSelectUser
         self.onSelectBook = onSelectBook
+        self.onSelectAddBook = onSelectAddBook
         self.onSelectBulkAdd = onSelectBulkAdd
         self.onSelectLoanSettings = onSelectLoanSettings
     }
@@ -51,6 +54,13 @@ public struct SettingsView: View {
                 title: "絵本管理",
                 subtitle: "\(bookCount)冊登録済み",
                 action: onSelectBook
+            )
+            
+            SettingsMenuItem(
+                iconName: "plus",
+                title: "絵本追加",
+                subtitle: "新しい絵本を1冊ずつ追加",
+                action: onSelectAddBook
             )
             
             SettingsMenuItem(
@@ -117,6 +127,7 @@ private struct SettingsMenuItem: View {
             maxBooksPerUser: 1,
             onSelectUser: {},
             onSelectBook: {},
+            onSelectAddBook: {},
             onSelectBulkAdd: {},
             onSelectLoanSettings: {}
         )


### PR DESCRIPTION
## Summary
- 絵本登録時のカメラ撮影機能を追加（フォトライブラリは使わずカメラのみ）
- 設定画面に端末初期化機能を追加（利用者、絵本、貸出記録の選択削除）
- 管理番号バッジUIを統一し、統一されたコンポーネントを作成
- 一括登録時の失敗絵本の連続個別登録機能を実装

### 📸 カメラ撮影機能
- UIImagePickerControllerを使用したカメラ機能
- 撮影画像のローカル保存（Documents/BookImages）
- macOS対応のための条件分岐実装
- サムネイルフィールドにローカルパスを保存

### 🗑️ 端末初期化機能
- チェックボックスによる削除対象選択
- 利用者データ、絵本データ、貸出記録の削除
- 削除件数の詳細表示とフィードバック
- 全Model層にdeleteAllメソッドを実装

### 🔄 一括登録改善
- 失敗した絵本の連続個別登録機能
- 進捗表示と順次ナビゲーション
- スキップ機能付きの登録フロー

### 🎨 UI統一
- ManagementNumberBadgeコンポーネント作成
- 複数スタイル対応（primary, success, secondary）
- 一貫したデザインシステム適用

## Test plan
- [x] カメラ撮影機能の動作確認
- [x] 端末初期化での実際のデータ削除確認
- [x] 一括登録失敗本の個別登録フロー確認
- [x] macOS/iOS両プラットフォームでのビルド確認
- [x] 管理番号バッジの表示統一確認

🤖 Generated with [Claude Code](https://claude.ai/code)