### PR TITLE
AlertStateエラーハンドリング改善とユーザー種別フィルタUI改善

### DIFF
--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/States/AlertState.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/States/AlertState.swift
@@ -29,7 +29,7 @@ struct AlertState {
         AlertState(isPresented: true, title: title, message: message, type: .confirmation)
     }
     
-    static func info(_ message: String) -> AlertState {
-        AlertState(isPresented: true, title: "情報", message: message, type: .info)
+    static func info(_ title: String, message: String = "") -> AlertState {
+        AlertState(isPresented: true, title: title, message: message, type: .info)
     }
 }

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/States/AlertState.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/States/AlertState.swift
@@ -17,8 +17,8 @@ struct AlertState {
         case info
     }
     
-    static func error(_ message: String) -> AlertState {
-        AlertState(isPresented: true, title: "エラー", message: message, type: .error)
+    static func error(_ title: String, message: String) -> AlertState {
+        AlertState(isPresented: true, title: title, message: message, type: .error)
     }
     
     static func success(_ message: String) -> AlertState {

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/BookBulkAddContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/BookBulkAddContainerView.swift
@@ -282,7 +282,7 @@ struct BookBulkAddContainerView: View {
             refreshProcessedBooks()
             
         } catch {
-            alertState = .error("テキスト解析でエラーが発生しました: \(error.localizedDescription)")
+            alertState = .error("テキスト解析でエラーが発生しました", message: "\(error.localizedDescription)")
         }
     }
     
@@ -324,7 +324,7 @@ struct BookBulkAddContainerView: View {
             }
             
         } catch {
-            alertState = .error("保存でエラーが発生しました: \(error.localizedDescription)")
+            alertState = .error("絵本の保存に失敗しました", message: "\(error.localizedDescription)")
         }
     }
     

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/BookDetailContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/BookDetailContainerView.swift
@@ -40,7 +40,7 @@ struct BookDetailContainerView: View {
             do {
                 _ = try bookModel.updateBook(newValue)
             } catch {
-                alertState = .error(error.localizedDescription)
+                alertState = .error("絵本情報の更新に失敗しました", message: error.localizedDescription)
             }
         }
     }

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/BookFormContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/BookFormContainerView.swift
@@ -162,7 +162,7 @@ struct BookFormContainerView: View {
             onSave?(savedBook)
             dismiss()
         } catch {
-            alertState = .error("保存に失敗しました: \(error.localizedDescription)")
+            alertState = .error("絵本の保存に失敗しました", message: "\(error.localizedDescription)")
         }
     }
     
@@ -216,7 +216,7 @@ struct BookFormContainerView: View {
                 book.thumbnail = localPath
                 
             } catch {
-                alertState = .error("画像の保存に失敗しました: \(error.localizedDescription)")
+                alertState = .error("画像の保存に失敗しました", message: "\(error.localizedDescription)")
             }
         }
     #endif

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/BookListContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/BookListContainerView.swift
@@ -151,7 +151,7 @@ struct BookListContainerView: View {
         do {
             _ = try bookModel.deleteBook(book.id)
         } catch {
-            alertState = .error("絵本の削除に失敗しました: \(error.localizedDescription)")
+            alertState = .error("絵本の削除に失敗しました", message: "\(error.localizedDescription)")
         }
     }
 }

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/SettingsBookListContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/SettingsBookListContainerView.swift
@@ -144,7 +144,7 @@ struct SettingsBookListContainerView: View {
         do {
             _ = try bookModel.deleteBook(book.id)
         } catch {
-            alertState = .error("絵本の削除に失敗しました: \(error.localizedDescription)")
+            alertState = .error("絵本の削除に失敗しました", message: "\(error.localizedDescription)")
         }
     }
 }

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/ClassGroup/ClassGroupListContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/ClassGroup/ClassGroupListContainerView.swift
@@ -116,7 +116,7 @@ struct ClassGroupListContainerView: View {
             do {
                 try classGroupModel.deleteClassGroup(classGroup.id)
             } catch {
-                alertState = .error("組の削除に失敗しました")
+                alertState = .error("組の削除に失敗しました", message: error.localizedDescription)
             }
         }
     }
@@ -126,7 +126,7 @@ struct ClassGroupListContainerView: View {
             try classGroupModel.registerClassGroup(classGroup)
             isAddSheetPresented = false
         } catch {
-            alertState = .error("組の追加に失敗しました")
+            alertState = .error("組の追加に失敗しました", message: error.localizedDescription)
         }
     }
     
@@ -135,7 +135,7 @@ struct ClassGroupListContainerView: View {
             try classGroupModel.updateClassGroup(classGroup)
             editingClassGroup = nil
         } catch {
-            alertState = .error("組の更新に失敗しました")
+            alertState = .error("組の更新に失敗しました", message: error.localizedDescription)
         }
     }
 }

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Loan/LoanActionContainerButton.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Loan/LoanActionContainerButton.swift
@@ -94,7 +94,7 @@ struct LoanActionContainerButton: View {
                 try loanModel.returnBook(bookId: bookId)
                 alertState = .success("返却が完了しました")
             } catch {
-                alertState = .error(error.localizedDescription)
+                alertState = .error("返却処理に失敗しました", message: error.localizedDescription)
             }
         }
     }

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Loan/LoanFormContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Loan/LoanFormContainerView.swift
@@ -47,6 +47,7 @@ struct LoanFormContainerView: View {
                 selectedUser = nil
             }
             .navigationTitle("貸出登録")
+            .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("キャンセル") {
@@ -141,12 +142,6 @@ struct LoanFormContainerView: View {
             
             _ = try loanModel.lendBook(bookId: selectedBook.id, userId: user.id)
             alertState = .success("貸出登録が完了しました")
-        } catch LoanModelError.bookAlreadyLent {
-            alertState = .error("この絵本はすでに貸出中です")
-        } catch LoanModelError.bookNotFound {
-            alertState = .error("選択された絵本が見つかりません")
-        } catch LoanModelError.userNotFound {
-            alertState = .error("選択された利用者が見つかりません")
         } catch {
             alertState = .error("貸出登録に失敗しました: \(error.localizedDescription)")
         }

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Loan/LoanFormContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Loan/LoanFormContainerView.swift
@@ -47,7 +47,9 @@ struct LoanFormContainerView: View {
                 selectedUser = nil
             }
             .navigationTitle("貸出登録")
-            .navigationBarTitleDisplayMode(.inline)
+            #if os(iOS)
+                .navigationBarTitleDisplayMode(.inline)
+            #endif
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("キャンセル") {
@@ -126,7 +128,7 @@ struct LoanFormContainerView: View {
     
     private func handleRegister() {
         guard let user = selectedUser else {
-            alertState = .error("必要な情報が選択されていません")
+            alertState = .error("貸出登録に失敗しました", message: "必要な情報が選択されていません")
             return
         }
         
@@ -136,14 +138,14 @@ struct LoanFormContainerView: View {
             
             // すでに貸出中かどうか再確認
             if loanModel.isBookLent(bookId: selectedBook.id) {
-                alertState = .error("この絵本はすでに貸出中です")
+                alertState = .error("貸出登録に失敗しました", message: "この絵本はすでに貸出中です")
                 return
             }
             
             _ = try loanModel.lendBook(bookId: selectedBook.id, userId: user.id)
             alertState = .success("貸出登録が完了しました")
         } catch {
-            alertState = .error("貸出登録に失敗しました: \(error.localizedDescription)")
+            alertState = .error("貸出登録に失敗しました", message: "\(error.localizedDescription)")
         }
     }
     

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/LoanConfirmationContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/LoanConfirmationContainerView.swift
@@ -59,7 +59,7 @@ struct LoanConfirmationContainerView: View {
             onComplete()
             dismiss()
         } catch {
-            alertState = .error("貸出処理に失敗しました")
+            alertState = .error("貸出処理に失敗しました", message: error.localizedDescription)
         }
     }
     

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Settings/LoanSettingsContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Settings/LoanSettingsContainerView.swift
@@ -53,7 +53,8 @@ struct LoanSettingsContainerView: View {
             defaultLoanPeriodDays: loanPeriodDays, maxBooksPerUser: maxBooksPerUser)
         
         guard newSettings.isValid() else {
-            alertState = .error("設定値が無効です。貸出期間は1日〜365日、貸出可能数は1冊以上で設定してください。")
+            alertState = .error(
+                "設定の保存に失敗しました", message: "設定値が無効です。貸出期間は1日〜365日、貸出可能数は1冊以上で設定してください。")
             return
         }
         
@@ -63,7 +64,7 @@ struct LoanSettingsContainerView: View {
             // 成功時は即座に画面を閉じる
             dismiss()
         } catch {
-            alertState = .error("設定の保存に失敗しました: \(error.localizedDescription)")
+            alertState = .error("設定の保存に失敗しました", message: "\(error.localizedDescription)")
         }
     }
     

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/SettingsContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/SettingsContainerView.swift
@@ -136,7 +136,7 @@ struct SettingsContainerView: View {
             // 園児のみを取得
             let children = userModel.users.filter { $0.userType == .child }
             if children.isEmpty {
-                alertState = .error("登録されている園児がいません")
+                alertState = .error("保護者作成に失敗しました", message: "登録されている園児がいません")
                 return
             }
             
@@ -174,7 +174,7 @@ struct SettingsContainerView: View {
             
             alertState = .info(message)
         } catch {
-            alertState = .error("保護者作成中にエラーが発生しました: \(error.localizedDescription)")
+            alertState = .error("保護者作成に失敗しました", message: "\(error.localizedDescription)")
         }
     }
     
@@ -208,7 +208,7 @@ struct SettingsContainerView: View {
             alertState = .info(message)
             
         } catch {
-            alertState = .error("削除中にエラーが発生しました: \(error.localizedDescription)")
+            alertState = .error("データ削除に失敗しました", message: "\(error.localizedDescription)")
         }
     }
     
@@ -246,7 +246,7 @@ struct SettingsContainerView: View {
             alertState = .info("進級処理が完了しました。", message: graduationMessage)
             
         } catch {
-            alertState = .error("進級処理中にエラーが発生しました: \(error.localizedDescription)")
+            alertState = .error("進級処理に失敗しました", message: "\(error.localizedDescription)")
         }
     }
     

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/SettingsContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/SettingsContainerView.swift
@@ -136,7 +136,7 @@ struct SettingsContainerView: View {
             // 園児のみを取得
             let children = userModel.users.filter { $0.userType == .child }
             if children.isEmpty {
-                alertState = .info("登録されている園児がいません")
+                alertState = .error("登録されている園児がいません")
                 return
             }
             
@@ -173,7 +173,6 @@ struct SettingsContainerView: View {
                 }
             
             alertState = .info(message)
-            
         } catch {
             alertState = .error("保護者作成中にエラーが発生しました: \(error.localizedDescription)")
         }
@@ -213,11 +212,38 @@ struct SettingsContainerView: View {
         }
     }
     
+    /// 進級対応
     private func performPromoteToNextYear() async {
         do {
-            try classGroupModel.promoteToNextYear()
+            // クラス進級処理を実行し、削除されたクラスを取得
+            let deletedClassGroups = try classGroupModel.promoteToNextYear()
+            var graduationTextArray: [String] = []
             
-            alertState = .info("進級処理が完了しました")
+            // 削除されたクラスに所属していたユーザーも削除し、卒業メッセージを作成
+            for deletedClassGroup in deletedClassGroups {
+                // 該当クラスのユーザーを取得（削除前に園児数をカウント）
+                let usersInClass = userModel.users.filter { user in
+                    user.classGroupId == deletedClassGroup.id
+                }
+                
+                // ユーザー削除
+                _ = try userModel.deleteUsersInClassGroup(deletedClassGroup.id)
+                
+                // 卒業メッセージを作成（園児がいる場合のみ）
+                let childrenCount = usersInClass.filter { $0.userType == .child }.count
+                if childrenCount > 0 {
+                    graduationTextArray.append(
+                        "\(deletedClassGroup.year)年度の\(deletedClassGroup.name)組 \(childrenCount)人")
+                }
+            }
+            // 卒業メッセージ
+            let graduationMessage = {
+                guard !graduationTextArray.isEmpty else { return "" }
+                graduationTextArray.append("が卒業しました🌸")
+                return graduationTextArray.joined(separator: "\n")
+            }()
+            
+            alertState = .info("進級処理が完了しました。", message: graduationMessage)
             
         } catch {
             alertState = .error("進級処理中にエラーが発生しました: \(error.localizedDescription)")

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/User/UserDetailContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/User/UserDetailContainerView.swift
@@ -69,7 +69,7 @@ struct UserDetailContainerView: View {
             _ = try userModel.updateUser(updatedUser)
             alertState = .success("利用者情報を保存しました")
         } catch {
-            alertState = .error("利用者情報の保存に失敗しました: \(error.localizedDescription)")
+            alertState = .error("利用者情報の保存に失敗しました", message: "\(error.localizedDescription)")
         }
     }
     

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/User/UserFormContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/User/UserFormContainerView.swift
@@ -95,7 +95,7 @@ struct UserFormContainerView: View {
     
     private func handleSave() {
         guard let selectedClassGroup = classGroup else {
-            alertState = .error("組を選択してください")
+            alertState = .error("利用者登録に失敗しました", message: "組を選択してください")
             return
         }
         
@@ -106,7 +106,7 @@ struct UserFormContainerView: View {
         case .guardian:
             // 新規登録で保護者を直接登録する場合は、選択された園児のIDを使用
             guard let selectedChild = selectedChild else {
-                alertState = .error("保護者を登録する場合は関連する園児を選択してください")
+                alertState = .error("利用者登録に失敗しました", message: "保護者を登録する場合は関連する園児を選択してください")
                 return
             }
             userType = .guardian(relatedChildId: selectedChild.id)
@@ -136,7 +136,7 @@ struct UserFormContainerView: View {
             
             dismiss()
         } catch {
-            alertState = .error("保存に失敗しました: \(error.localizedDescription)")
+            alertState = .error("利用者保存に失敗しました", message: "\(error.localizedDescription)")
         }
     }
     

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/User/UserListContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/User/UserListContainerView.swift
@@ -125,7 +125,7 @@ struct UserListContainerView: View {
                 do {
                     _ = try userModel.deleteUser(user.id)
                 } catch {
-                    alertState = .error("利用者の削除に失敗しました: \(error.localizedDescription)")
+                    alertState = .error("利用者の削除に失敗しました", message: "\(error.localizedDescription)")
                 }
             }
             return
@@ -164,7 +164,7 @@ struct UserListContainerView: View {
         do {
             _ = try userModel.deleteUser(user.id)
         } catch {
-            alertState = .error("利用者の削除に失敗しました: \(error.localizedDescription)")
+            alertState = .error("利用者の削除に失敗しました", message: "\(error.localizedDescription)")
         }
         
         userToDelete = nil

--- a/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Loan/LoanFormView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Loan/LoanFormView.swift
@@ -73,15 +73,13 @@ public struct LoanFormView: View {
             }
             
             if selectedClassGroup != nil {
-                Section(header: Text("利用者種別")) {
+                
+                Section(header: Text("利用者を選択")) {
                     Picker("利用者種別", selection: $selectedUserTypeCategory) {
                         Text("園児").tag(UserTypeCategory.child)
                         Text("保護者").tag(UserTypeCategory.guardian)
                     }
                     .pickerStyle(.segmented)
-                }
-                
-                Section(header: Text("利用者を選択")) {
                     if users.isEmpty {
                         Text(
                             selectedUserTypeCategory == .child
@@ -130,17 +128,20 @@ public struct LoanFormView: View {
         User(name: "鈴木花子", classGroupId: sampleClassGroup.id),
     ]
     
-    NavigationStack {
-        LoanFormView(
-            book: sampleBook,
-            classGroups: sampleClassGroups,
-            users: sampleUsers,
-            dueDate: Date(),
-            selectedClassGroup: $selectedClassGroup,
-            selectedUser: $selectedUser,
-            selectedUserTypeCategory: $selectedUserTypeCategory,
-            isValidInput: selectedClassGroup != nil && selectedUser != nil
-        )
-        .navigationTitle("貸出登録")
-    }
+    Text("test")
+        .sheet(isPresented: .constant(true)) {
+            NavigationStack {
+                LoanFormView(
+                    book: sampleBook,
+                    classGroups: sampleClassGroups,
+                    users: sampleUsers,
+                    dueDate: Date(),
+                    selectedClassGroup: $selectedClassGroup,
+                    selectedUser: $selectedUser,
+                    selectedUserTypeCategory: $selectedUserTypeCategory,
+                    isValidInput: selectedClassGroup != nil && selectedUser != nil
+                )
+            }
+            .navigationTitle("貸出登録")
+        }
 }


### PR DESCRIPTION
## Summary

このPRでは、AlertStateのエラーハンドリングを大幅に改善し、ユーザー種別フィルタ機能の実装を完了しました。

### 🎯 主な改善点

#### 1. AlertStateエラーハンドリングの改善
- **コンテキスト認識エラータイトル**: 汎用的な「エラー」から具体的な「貸出登録に失敗しました」「利用者保存に失敗しました」等に変更
- **タイトル・メッセージ分離**: エラーの種類（タイトル）と技術的詳細（メッセージ）を明確に分離
- **25+箇所の統一**: 全体で一貫した「XXに失敗しました」パターンを適用
- **強制的なコンテキスト指定**: AlertState.error()でtitleパラメータを必須にして適切なエラー表示を保証

#### 2. ユーザー種別フィルタUI改善
- **セグメント型フィルタ**: トグルからセグメントコントロールに変更してより直感的なUX
- **園児デフォルト選択**: 最も一般的なユースケースに対応
- **自動ソート機能**: 選択した種別でフィルタし名前順に自動ソート
- **リアルタイム更新**: 組や種別変更時に即座にユーザーリストを更新

#### 3. 進級処理の強化
- **温かい卒業メッセージ**: 冷たい削除通知から「2025年度のひまわり組 8人が卒業しました🌸」に変更
- **ClassGroupModelとUserModelの責任分離**: 適切な役割分担でより保守性の高い設計

#### 4. プラットフォーム互換性
- **macOS対応**: navigationBarTitleDisplayModeを条件分岐で適切に処理

### 🧪 Test plan

- [x] 全25+箇所でエラー表示が適切にタイトル・メッセージ分離されていることを確認
- [x] ユーザー種別フィルタが期待通りに動作することを確認
- [x] 進級処理で温かいメッセージが表示されることを確認
- [x] macOSとiOS両プラットフォームでビルドが成功することを確認
- [x] swift-formatがすべてのファイルで正常に実行されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)