### PR TITLE
feat: 管理番号ソートを文字列数字文字列パターンに対応

### DIFF
--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/States/BookSections.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/States/BookSections.swift
@@ -89,16 +89,36 @@ extension BookSection {
 }
 
 /// 管理番号のソート用キーを作成
+/// "文字列数字文字列"パターンに対応（例: "abc123def", "あ001-a"）
 /// 全角数字と半角数字の両方に対応
 private func sortKey(_ text: String) -> (hiragana: String, number: Int) {
-    // 先頭のひらがな
-    let prefix = String(text.prefix(1))
+    let normalizedText = normalizeNumbers(text)
     
-    // 残りの部分から数字を抜き出す（全角・半角両対応）
-    let remainingText = String(text.dropFirst())
-    let normalizedText = normalizeNumbers(remainingText)
-    let numberPart = normalizedText.prefix { $0.isNumber }
-    let number = Int(numberPart) ?? 0
+    // 最初の数字列を見つける
+    var stringPrefix = ""
+    var numberString = ""
+    var foundNumber = false
+    
+    for char in normalizedText {
+        if char.isNumber {
+            if !foundNumber {
+                foundNumber = true
+            }
+            numberString.append(char)
+        } else {
+            if foundNumber {
+                // 数字の後の文字が来たら数字部分の抽出完了
+                break
+            } else {
+                // まだ数字が見つかってない場合は文字列部分
+                stringPrefix.append(char)
+            }
+        }
+    }
+    
+    // 文字列部分が空の場合は元のテキストを使用
+    let prefix = stringPrefix.isEmpty ? text : stringPrefix
+    let number = Int(numberString) ?? 0
     
     return (prefix, number)
 }

--- a/PictureBookLendingAdminApp/PictureBookLendingAdminTests/BookSectionTests.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdminTests/BookSectionTests.swift
@@ -329,6 +329,66 @@ struct BookSectionTests {
         #expect(books[3].managementNumber == "さ010")  // さ010
     }
     
+    /// 文字列数字文字列パターンのソートテスト
+    ///
+    /// "abc123def"のような文字列数字文字列パターンが正しくソートされることを確認します。
+    @Test("文字列数字文字列パターンのソート")
+    func sortedByStringNumberStringPattern() {
+        // 1. Arrange - 準備（文字列＋数字＋文字列パターン）
+        let patternBooks = [
+            Book(title: "本A", managementNumber: "book010-a", kanaGroup: .other),
+            Book(title: "本B", managementNumber: "book005-b", kanaGroup: .other),
+            Book(title: "本C", managementNumber: "abc123def", kanaGroup: .other),
+            Book(title: "本D", managementNumber: "abc050xyz", kanaGroup: .other),
+            Book(title: "本E", managementNumber: "book100", kanaGroup: .other),  // 末尾文字列なし
+        ]
+        let sections = BookSection.createSections(from: patternBooks)
+        
+        // 2. Act - 実行
+        let sortedSections = BookSection.sorted(sections: sections, by: .managementNumber)
+        
+        // 3. Assert - 検証
+        #expect(sortedSections.count == 1)
+        let books = sortedSections[0].books
+        
+        // 文字列部分順 → 数字順
+        #expect(books[0].managementNumber == "abc050xyz")  // abc50
+        #expect(books[1].managementNumber == "abc123def")  // abc123
+        #expect(books[2].managementNumber == "book005-b")  // book5
+        #expect(books[3].managementNumber == "book010-a")  // book10
+        #expect(books[4].managementNumber == "book100")  // book100
+    }
+    
+    /// 複雑な管理番号パターンのソートテスト
+    ///
+    /// ひらがな、英数字、記号を含む複雑なパターンのソートを確認します。
+    @Test("複雑な管理番号パターンのソート")
+    func sortedByComplexPatterns() {
+        // 1. Arrange - 準備
+        let complexBooks = [
+            Book(title: "本A", managementNumber: "あ１０", kanaGroup: .other),  // ひらがな＋全角数字
+            Book(title: "本B", managementNumber: "A005-x", kanaGroup: .other),  // 英字＋数字＋文字
+            Book(title: "本C", managementNumber: "あ05", kanaGroup: .other),  // ひらがな＋半角数字
+            Book(title: "本D", managementNumber: "B003", kanaGroup: .other),  // 英字＋数字
+            Book(title: "本E", managementNumber: "A010", kanaGroup: .other),  // 英字＋数字
+        ]
+        let sections = BookSection.createSections(from: complexBooks)
+        
+        // 2. Act - 実行
+        let sortedSections = BookSection.sorted(sections: sections, by: .managementNumber)
+        
+        // 3. Assert - 検証
+        #expect(sortedSections.count == 1)
+        let books = sortedSections[0].books
+        
+        // 文字列部分のアルファベット順・ひらがな順、その中で数字順
+        #expect(books[0].managementNumber == "A005-x")  // A005
+        #expect(books[1].managementNumber == "A010")  // A010
+        #expect(books[2].managementNumber == "B003")  // B003
+        #expect(books[3].managementNumber == "あ05")  // あ05
+        #expect(books[4].managementNumber == "あ１０")  // あ10
+    }
+    
     // MARK: - Integration Tests
     
     /// 全機能統合テスト


### PR DESCRIPTION
## Summary
- sortKey関数を改修し、複雑な管理番号パターン（"abc123def"、"book010-a" など）に対応
- 文字列部分と数字部分を正しく分離してソートするよう改善
- 新しいテストケースを追加して複雑パターンの動作を保証

## Test plan
- [x] 既存のテストケースがすべて通ることを確認
- [x] 新しいテストケース「文字列数字文字列パターンのソート」を追加
- [x] 新しいテストケース「複雑な管理番号パターンのソート」を追加
- [x] ビルドが正常に完了することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)