### PR TITLE
Fix return completion dialog issue in lending management screen

### DIFF
--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/BookDetailContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/BookDetailContainerView.swift
@@ -25,7 +25,7 @@ struct BookDetailContainerView: View {
             currentLoan: currentLoan,
             loanHistory: loanHistory,
         ) {
-            LoanActionContainerButton(bookId: book.id)
+            LoanActionContainerButton(bookId: book.id, onReturnSuccess: nil)
         }
         .navigationTitle(book.title)
         #if os(iOS)

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/BookListContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/BookListContainerView.swift
@@ -50,7 +50,7 @@ struct BookListContainerView: View {
             if isEditMode {
                 BookStatusView(isCurrentlyLent: loanModel.isBookLent(bookId: book.id))
             } else {
-                LoanActionContainerButton(bookId: book.id)
+                LoanActionContainerButton(bookId: book.id, onReturnSuccess: nil)
             }
         }
         #if os(iOS)

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Loan/LoanActionContainerButton.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Loan/LoanActionContainerButton.swift
@@ -11,6 +11,8 @@ import SwiftUI
 struct LoanActionContainerButton: View {
     /// 対象絵本のID
     let bookId: UUID
+    /// 返却完了時のコールバック（オプション）
+    let onReturnSuccess: ((String) -> Void)?
     
     /// 絵本管理モデル
     @Environment(BookModel.self) private var bookModel
@@ -92,7 +94,12 @@ struct LoanActionContainerButton: View {
         Task {
             do {
                 try loanModel.returnBook(bookId: bookId)
-                alertState = .success("返却が完了しました")
+                // コールバックが提供されている場合は親に成功を通知、そうでなければ自身でアラート表示
+                if let onReturnSuccess = onReturnSuccess {
+                    onReturnSuccess("返却が完了しました")
+                } else {
+                    alertState = .success("返却が完了しました")
+                }
             } catch {
                 alertState = .error("返却処理に失敗しました", message: error.localizedDescription)
             }
@@ -115,7 +122,7 @@ struct LoanActionContainerButton: View {
     let sampleBook = Book(title: "はらぺこあおむし", author: "エリック・カール", managementNumber: "あ001")
     
     VStack(spacing: 16) {
-        LoanActionContainerButton(bookId: sampleBook.id)
+        LoanActionContainerButton(bookId: sampleBook.id, onReturnSuccess: nil)
         
         // リスト内での表示例
         List {
@@ -130,7 +137,7 @@ struct LoanActionContainerButton: View {
                 
                 Spacer()
                 
-                LoanActionContainerButton(bookId: sampleBook.id)
+                LoanActionContainerButton(bookId: sampleBook.id, onReturnSuccess: nil)
             }
             .padding(.vertical, 4)
         }

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Loan/LoanListContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Loan/LoanListContainerView.swift
@@ -26,7 +26,10 @@ struct LoanListContainerView: View {
             selectedGroupFilter: $selectedGroupFilter,
             groupFilterOptions: groupFilterOptions
         ) { loan in
-            LoanActionContainerButton(bookId: loan.bookId)
+            LoanActionContainerButton(
+                bookId: loan.bookId,
+                onReturnSuccess: handleReturnSuccess
+            )
         }
         .navigationTitle("貸出管理")
         .toolbar {
@@ -124,6 +127,11 @@ struct LoanListContainerView: View {
         bookModel.refreshBooks()
         loanModel.refreshLoans()
         classGroupModel.refreshClassGroups()
+    }
+    
+    /// 返却成功時の処理
+    private func handleReturnSuccess(_ message: String) {
+        alertState = .success(message)
     }
 }
 

--- a/PictureBookLendingAdminApp/PictureBookLendingDomain/Package.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingDomain/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.2
+// swift-tools-version: 6.1
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/PictureBookLendingAdminApp/PictureBookLendingInfrastructure/Package.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingInfrastructure/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.2
+// swift-tools-version: 6.1
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/PictureBookLendingAdminApp/PictureBookLendingModel/Package.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingModel/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.2
+// swift-tools-version: 6.1
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/PictureBookLendingAdminApp/PictureBookLendingUI/Package.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingUI/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.2
+// swift-tools-version: 6.1
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription


### PR DESCRIPTION
Fixes #124

This PR addresses the issue where return completion dialogs were not being displayed in the lending management screen.

## Changes
- Added optional `onReturnSuccess` callback to `LoanActionContainerButton`
- Updated `LoanListContainerView` to handle return success alerts properly
- Fixed Swift tools version compatibility (6.2 → 6.1) in all Package.swift
- Maintained backward compatibility for existing usages

## Testing
The fix ensures return completion dialogs are displayed consistently across both:
- Book list screen (絵本一覧)
- Lending management screen (貸出管理)

🤖 Generated with [Claude Code](https://claude.ai/code)