### PR TITLE
fix: TestFlightアップデート後の画像表示問題を修正

### DIFF
--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/BookFormContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/BookFormContainerView.swift
@@ -209,11 +209,11 @@ struct BookFormContainerView: View {
             isCameraPresented = false
             
             do {
-                // 画像をローカルに保存
-                let localPath = try ImageStorageUtility.saveImage(image)
+                // 画像をローカルに保存（ファイル名のみが返される）
+                let fileName = try ImageStorageUtility.saveImage(image)
                 
-                // Bookのthumbnailフィールドにローカルパスを設定
-                book.thumbnail = localPath
+                // BookのlocalImageFileNameフィールドにファイル名を設定
+                book.localImageFileName = fileName
                 
             } catch {
                 alertState = .error("画像の保存に失敗しました", message: "\(error.localizedDescription)")

--- a/PictureBookLendingAdminApp/PictureBookLendingDomain/Sources/PictureBookLendingDomain/Domain/Book.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingDomain/Sources/PictureBookLendingDomain/Domain/Book.swift
@@ -21,6 +21,8 @@ public struct Book: Identifiable, Codable, Hashable, Sendable {
     public var smallThumbnail: String?
     /// 通常サイズのサムネイル画像のURL
     public var thumbnail: String?
+    /// ローカル保存された画像のファイル名
+    public var localImageFileName: String?
     /// 対象読者
     public var targetAge: TargetAudience?
     /// ページ数
@@ -43,6 +45,7 @@ public struct Book: Identifiable, Codable, Hashable, Sendable {
     ///   - description: 説明・あらすじ（任意）
     ///   - smallThumbnail: 小さなサムネイル画像のURL（任意）
     ///   - thumbnail: 通常サイズのサムネイル画像のURL（任意）
+    ///   - localImageFileName: ローカル保存された画像のファイル名（任意）
     ///   - targetAge: 対象年齢（任意）
     ///   - pageCount: ページ数（任意）
     ///   - categories: カテゴリ・ジャンル（デフォルトは空配列）
@@ -58,6 +61,7 @@ public struct Book: Identifiable, Codable, Hashable, Sendable {
         description: String? = nil,
         smallThumbnail: String? = nil,
         thumbnail: String? = nil,
+        localImageFileName: String? = nil,
         targetAge: TargetAudience? = nil,
         pageCount: Int? = nil,
         categories: [String] = [],
@@ -74,6 +78,7 @@ public struct Book: Identifiable, Codable, Hashable, Sendable {
         self.description = description
         self.smallThumbnail = smallThumbnail
         self.thumbnail = thumbnail
+        self.localImageFileName = localImageFileName
         self.targetAge = targetAge
         self.pageCount = pageCount
         self.categories = categories

--- a/PictureBookLendingAdminApp/PictureBookLendingDomain/Sources/PictureBookLendingDomain/Domain/Book.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingDomain/Sources/PictureBookLendingDomain/Domain/Book.swift
@@ -85,4 +85,37 @@ public struct Book: Identifiable, Codable, Hashable, Sendable {
         self.kanaGroup = kanaGroup
     }
     
+    /// 表示用の画像URLを取得する
+    /// ローカル画像が存在する場合はfile://付きフルパスを返し、そうでなければ外部URLを返す
+    /// - Returns: 画像のURL（存在しない場合はnil）
+    public var displayImageSource: String? {
+        // ローカル画像が存在する場合は優先してfile://付きフルパスを返す
+        if let localImageFileName = localImageFileName {
+            let documentsURL = FileManager.default.urls(
+                for: .documentDirectory, in: .userDomainMask
+            ).first!
+            let imageDirectoryURL = documentsURL.appendingPathComponent("BookImages")
+            let fileURL = imageDirectoryURL.appendingPathComponent(localImageFileName)
+            return fileURL.absoluteString
+        }
+        // 外部URLのサムネイル
+        return thumbnail ?? smallThumbnail
+    }
+    
+    /// 表示用の画像URLを取得する（小さいサムネイル優先）
+    /// ローカル画像が存在する場合はfile://付きフルパスを返し、そうでなければ外部URLを返す
+    /// - Returns: 画像のURL（存在しない場合はnil）
+    public var displaySmallImageSource: String? {
+        // ローカル画像が存在する場合は優先してfile://付きフルパスを返す
+        if let localImageFileName = localImageFileName {
+            let documentsURL = FileManager.default.urls(
+                for: .documentDirectory, in: .userDomainMask
+            ).first!
+            let imageDirectoryURL = documentsURL.appendingPathComponent("BookImages")
+            let fileURL = imageDirectoryURL.appendingPathComponent(localImageFileName)
+            return fileURL.absoluteString
+        }
+        // 外部URLのサムネイル（小さいサイズ優先）
+        return smallThumbnail ?? thumbnail
+    }
 }

--- a/PictureBookLendingAdminApp/PictureBookLendingInfrastructure/Sources/PictureBookLendingInfrastructure/Repositories/Migration/MigrationPlan.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingInfrastructure/Sources/PictureBookLendingInfrastructure/Repositories/Migration/MigrationPlan.swift
@@ -5,17 +5,21 @@
 //  Created by takuya_tominaga on 8/28/25.
 //
 
+import Foundation
 import SwiftData
 
 extension MigrationStage: @unchecked @retroactive Sendable {}
 
 enum PictureBookLendingMigrationPlan: SchemaMigrationPlan {
     static var schemas: [any VersionedSchema.Type] {
-        [PictureBookLendingSchemaV1.self, PictureBookLendingSchemaV1_1.self]
+        [
+            PictureBookLendingSchemaV1.self, PictureBookLendingSchemaV1_1.self,
+            PictureBookLendingSchemaV1_2.self,
+        ]
     }
     
     static var stages: [MigrationStage] {
-        [migrateV1ToV1_1]
+        [migrateV1ToV1_1, migrateV1_1ToV1_2]
     }
     
     static let migrateV1ToV1_1: MigrationStage = MigrationStage.custom(
@@ -27,5 +31,32 @@ enum PictureBookLendingMigrationPlan: SchemaMigrationPlan {
             try context.save()
         },
         didMigrate: nil
+    )
+
+    static let migrateV1_1ToV1_2: MigrationStage = MigrationStage.custom(
+        fromVersion: PictureBookLendingSchemaV1_1.self,
+        toVersion: PictureBookLendingSchemaV1_2.self,
+        willMigrate: nil,
+        didMigrate: { context in
+            // V1_2のBookデータを読み込み、thumbnailのfile://パスをlocalImageFileNameに移行
+            let books = try context.fetch(
+                FetchDescriptor<PictureBookLendingSchemaV1_2.SwiftDataBook>())
+            
+            for book in books {
+                // thumbnailに絶対パス（file://）が保存されている場合、ファイル名を抽出してlocalImageFileNameに移行
+                if let thumbnail = book.thumbnail, thumbnail.hasPrefix("file://") {
+                    // file://から始まるパスからファイル名のみを抽出
+                    if let url = URL(string: thumbnail) {
+                        let fileName = url.lastPathComponent
+                        // localImageFileNameに設定
+                        book.localImageFileName = fileName
+                        // thumbnailをクリア（外部URL専用にする）
+                        book.thumbnail = nil
+                    }
+                }
+            }
+            
+            try context.save()
+        }
     )
 }

--- a/PictureBookLendingAdminApp/PictureBookLendingInfrastructure/Sources/PictureBookLendingInfrastructure/Repositories/Migration/SchemaV1_2.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingInfrastructure/Sources/PictureBookLendingInfrastructure/Repositories/Migration/SchemaV1_2.swift
@@ -1,15 +1,15 @@
 //
-//  SchemaV1_1.swift
+//  SchemaV1_2.swift
 //  PictureBookLendingAdmin
 //
-//  Created by takuya_tominaga on 8/28/25.
+//  Created by takuya_tominaga on 9/4/25.
 //
 
 import Foundation
 import SwiftData
 
-struct PictureBookLendingSchemaV1_1: VersionedSchema {
-    static var versionIdentifier: Schema.Version { Schema.Version(1, 1, 0) }
+struct PictureBookLendingSchemaV1_2: VersionedSchema {
+    static var versionIdentifier: Schema.Version { Schema.Version(1, 2, 0) }
     static var models: [any PersistentModel.Type] {
         [
             SwiftDataLoan.self,
@@ -57,6 +57,7 @@ struct PictureBookLendingSchemaV1_1: VersionedSchema {
         public var bookDescription: String?
         public var smallThumbnail: String?
         public var thumbnail: String?
+        public var localImageFileName: String?  // 新しく追加されたフィールド
         public var targetAge: String?
         public var pageCount: Int?
         public var categories: [String]
@@ -72,6 +73,7 @@ struct PictureBookLendingSchemaV1_1: VersionedSchema {
             bookDescription: String? = nil,
             smallThumbnail: String? = nil,
             thumbnail: String? = nil,
+            localImageFileName: String? = nil,
             targetAge: String? = nil,
             pageCount: Int? = nil,
             categories: [String] = [],
@@ -88,25 +90,11 @@ struct PictureBookLendingSchemaV1_1: VersionedSchema {
             self.bookDescription = bookDescription
             self.smallThumbnail = smallThumbnail
             self.thumbnail = thumbnail
+            self.localImageFileName = localImageFileName
             self.targetAge = targetAge
             self.pageCount = pageCount
             self.categories = categories
             self.kanaGroup = kanaGroup
-        }
-    }
-    
-    @Model
-    final public class SwiftDataClassGroup {
-        @Attribute(.unique) public var id: UUID
-        public var name: String
-        public var ageGroup: String
-        public var year: Int
-        
-        public init(id: UUID, name: String, ageGroup: String, year: Int) {
-            self.id = id
-            self.name = name
-            self.ageGroup = ageGroup
-            self.year = year
         }
     }
     
@@ -139,6 +127,21 @@ struct PictureBookLendingSchemaV1_1: VersionedSchema {
         }
     }
     
+    @Model
+    final public class SwiftDataClassGroup {
+        @Attribute(.unique) public var id: UUID
+        public var name: String
+        public var ageGroup: String
+        public var year: Int
+        
+        public init(id: UUID, name: String, ageGroup: String, year: Int) {
+            self.id = id
+            self.name = name
+            self.ageGroup = ageGroup
+            self.year = year
+        }
+    }
+    
     public enum KanaGroup: String, CaseIterable, Sendable, Codable {
         case a = "あ"
         case ka = "か"
@@ -158,6 +161,7 @@ struct PictureBookLendingSchemaV1_1: VersionedSchema {
         public var name: String
         public var classGroupId: UUID
         public var userType: UserType
+        
         public init(
             id: UUID = UUID(),
             name: String,

--- a/PictureBookLendingAdminApp/PictureBookLendingInfrastructure/Sources/PictureBookLendingInfrastructure/Repositories/SwiftDataBook.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingInfrastructure/Sources/PictureBookLendingInfrastructure/Repositories/SwiftDataBook.swift
@@ -42,6 +42,9 @@ final public class SwiftDataBook {
     /// 通常サイズのサムネイル画像のURL
     public var thumbnail: String?
     
+    /// ローカル保存された画像のファイル名
+    public var localImageFileName: String?
+    
     /// 対象年齢（rawValue文字列として保存）
     public var targetAge: String?
     
@@ -67,6 +70,7 @@ final public class SwiftDataBook {
     ///   - bookDescription: 絵本の説明・概要
     ///   - smallThumbnail: 小さなサムネイル画像のURL
     ///   - thumbnail: 通常サイズのサムネイル画像のURL
+    ///   - localImageFileName: ローカル保存された画像のファイル名
     ///   - targetAge: 対象年齢
     ///   - pageCount: ページ数
     ///   - categories: カテゴリ・ジャンルの配列
@@ -81,6 +85,7 @@ final public class SwiftDataBook {
         bookDescription: String? = nil,
         smallThumbnail: String? = nil,
         thumbnail: String? = nil,
+        localImageFileName: String? = nil,
         targetAge: String? = nil,
         pageCount: Int? = nil,
         categories: [String] = [],
@@ -97,6 +102,7 @@ final public class SwiftDataBook {
         self.bookDescription = bookDescription
         self.smallThumbnail = smallThumbnail
         self.thumbnail = thumbnail
+        self.localImageFileName = localImageFileName
         self.targetAge = targetAge
         self.pageCount = pageCount
         self.categories = categories

--- a/PictureBookLendingAdminApp/PictureBookLendingInfrastructure/Sources/PictureBookLendingInfrastructure/Repositories/SwiftDataBookRepository.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingInfrastructure/Sources/PictureBookLendingInfrastructure/Repositories/SwiftDataBookRepository.swift
@@ -32,6 +32,7 @@ public final class SwiftDataBookRepository: BookRepositoryProtocol, @unchecked S
             bookDescription: book.description,
             smallThumbnail: book.smallThumbnail,
             thumbnail: book.thumbnail,
+            localImageFileName: book.localImageFileName,
             targetAge: book.targetAge?.rawValue,
             pageCount: book.pageCount,
             categories: book.categories,
@@ -70,6 +71,7 @@ public final class SwiftDataBookRepository: BookRepositoryProtocol, @unchecked S
                     description: swiftDataBook.bookDescription,
                     smallThumbnail: swiftDataBook.smallThumbnail,
                     thumbnail: swiftDataBook.thumbnail,
+                    localImageFileName: swiftDataBook.localImageFileName,
                     targetAge: swiftDataBook.targetAge.flatMap {
                         TargetAudience(rawValue: $0)
                     },
@@ -109,6 +111,7 @@ public final class SwiftDataBookRepository: BookRepositoryProtocol, @unchecked S
                 description: swiftDataBook.bookDescription,
                 smallThumbnail: swiftDataBook.smallThumbnail,
                 thumbnail: swiftDataBook.thumbnail,
+                localImageFileName: swiftDataBook.localImageFileName,
                 targetAge: swiftDataBook.targetAge.flatMap { TargetAudience(rawValue: $0) },
                 pageCount: swiftDataBook.pageCount,
                 categories: swiftDataBook.categories,
@@ -145,6 +148,7 @@ public final class SwiftDataBookRepository: BookRepositoryProtocol, @unchecked S
             swiftDataBook.bookDescription = book.description
             swiftDataBook.smallThumbnail = book.smallThumbnail
             swiftDataBook.thumbnail = book.thumbnail
+            swiftDataBook.localImageFileName = book.localImageFileName
             swiftDataBook.targetAge = book.targetAge?.rawValue
             swiftDataBook.pageCount = book.pageCount
             swiftDataBook.categories = book.categories

--- a/PictureBookLendingAdminApp/PictureBookLendingInfrastructure/Sources/PictureBookLendingInfrastructure/Utilities/ImageStorageUtility.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingInfrastructure/Sources/PictureBookLendingInfrastructure/Utilities/ImageStorageUtility.swift
@@ -32,11 +32,11 @@ public enum ImageStorageUtility {
             }
         }
         
-        /// 画像を保存してローカルパスを返す
+        /// 画像を保存してファイル名を返す
         /// - Parameters:
         ///   - image: 保存する画像
         ///   - fileName: ファイル名（拡張子なし、デフォルトでUUID生成）
-        /// - Returns: 保存されたファイルのローカルパス
+        /// - Returns: 保存されたファイル名（拡張子付き）
         /// - Throws: 保存に失敗した場合のエラー
         public static func saveImage(_ image: UIImage, fileName: String = UUID().uuidString) throws
             -> String
@@ -52,35 +52,44 @@ public enum ImageStorageUtility {
             
             try imageData.write(to: fileURL)
             
-            // ローカルパスを返す（file://スキームを含む）
-            return fileURL.absoluteString
+            // ファイル名のみを返す（アップデート時のコンテナID変更に対応）
+            return fullFileName
         }
         
-        /// ローカルパスから画像を読み込む
-        /// - Parameter localPath: ローカルファイルパス
+        /// ローカルパスまたはファイル名から画像を読み込む
+        /// - Parameter pathOrFileName: ローカルファイルパス（file://形式）またはファイル名
         /// - Returns: 読み込まれた画像（失敗時はnil）
-        public static func loadImage(from localPath: String) -> UIImage? {
-            guard let url = URL(string: localPath) else { return nil }
-            
-            // file://スキームの場合はローカルファイル
-            if url.scheme == "file" {
+        public static func loadImage(from pathOrFileName: String) -> UIImage? {
+            // TODO: file://スキームの後方互換性サポート - 将来的に削除予定
+            // file://スキームの場合は絶対パス（後方互換性のため）
+            if pathOrFileName.hasPrefix("file://") {
+                guard let url = URL(string: pathOrFileName) else { return nil }
                 return UIImage(contentsOfFile: url.path)
             }
             
-            // それ以外は従来のURL（リモート画像など）として扱う
-            return nil
+            // ファイル名のみの場合は動的にパスを構築
+            let fileURL = imageDirectoryURL.appendingPathComponent(pathOrFileName)
+            return UIImage(contentsOfFile: fileURL.path)
         }
         
-        /// 指定されたローカルパスの画像ファイルを削除
-        /// - Parameter localPath: 削除するファイルのローカルパス
+        /// 指定されたローカルパスまたはファイル名の画像ファイルを削除
+        /// - Parameter pathOrFileName: 削除するファイルのローカルパス（file://形式）またはファイル名
         /// - Returns: 削除に成功した場合はtrue
-        public static func deleteImage(at localPath: String) -> Bool {
-            guard let url = URL(string: localPath),
-                url.scheme == "file"
-            else { return false }
+        public static func deleteImage(at pathOrFileName: String) -> Bool {
+            let fileURL: URL
+            
+            // TODO: file://スキームの後方互換性サポート - 将来的に削除予定
+            // file://スキームの場合は絶対パス（後方互換性のため）
+            if pathOrFileName.hasPrefix("file://") {
+                guard let url = URL(string: pathOrFileName) else { return false }
+                fileURL = url
+            } else {
+                // ファイル名のみの場合は動的にパスを構築
+                fileURL = imageDirectoryURL.appendingPathComponent(pathOrFileName)
+            }
             
             do {
-                try FileManager.default.removeItem(at: url)
+                try FileManager.default.removeItem(at: fileURL)
                 return true
             } catch {
                 print("画像削除に失敗: \(error)")
@@ -88,14 +97,20 @@ public enum ImageStorageUtility {
             }
         }
         
-        /// ローカル画像パスかどうかを判定
-        /// - Parameter path: 判定する文字列
-        /// - Returns: ローカル画像パスの場合はtrue
-        public static func isLocalImagePath(_ path: String?) -> Bool {
-            guard let path = path,
-                let url = URL(string: path)
-            else { return false }
-            return url.scheme == "file"
+        /// ローカル画像パスまたはファイル名かどうかを判定
+        /// - Parameter pathOrFileName: 判定する文字列
+        /// - Returns: ローカル画像パスまたはファイル名の場合はtrue
+        public static func isLocalImage(_ pathOrFileName: String?) -> Bool {
+            guard let pathOrFileName = pathOrFileName else { return false }
+            
+            // TODO: file://スキームの後方互換性サポート - 将来的に削除予定
+            // file://スキームの場合はローカルパス
+            if pathOrFileName.hasPrefix("file://") {
+                return true
+            }
+            
+            // .jpgで終わる場合はローカル画像ファイル名と判定
+            return pathOrFileName.hasSuffix(".jpg")
         }
 
     #endif

--- a/PictureBookLendingAdminApp/PictureBookLendingInfrastructure/Sources/PictureBookLendingInfrastructure/Utilities/ImageStorageUtility.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingInfrastructure/Sources/PictureBookLendingInfrastructure/Utilities/ImageStorageUtility.swift
@@ -96,22 +96,6 @@ public enum ImageStorageUtility {
                 return false
             }
         }
-        
-        /// ローカル画像パスまたはファイル名かどうかを判定
-        /// - Parameter pathOrFileName: 判定する文字列
-        /// - Returns: ローカル画像パスまたはファイル名の場合はtrue
-        public static func isLocalImage(_ pathOrFileName: String?) -> Bool {
-            guard let pathOrFileName = pathOrFileName else { return false }
-            
-            // TODO: file://スキームの後方互換性サポート - 将来的に削除予定
-            // file://スキームの場合はローカルパス
-            if pathOrFileName.hasPrefix("file://") {
-                return true
-            }
-            
-            // .jpgで終わる場合はローカル画像ファイル名と判定
-            return pathOrFileName.hasSuffix(".jpg")
-        }
 
     #endif
 }

--- a/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookDetailView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookDetailView.swift
@@ -34,17 +34,15 @@ public struct BookDetailView<ActionButton: View>: View {
                 HStack {
                     Spacer()
                     
-                    KFImage(URL(string: book.thumbnail ?? book.smallThumbnail ?? ""))
-                        .placeholder {
-                            Image(systemName: "book.closed")
-                                .foregroundStyle(.secondary)
-                                .font(.system(size: 48))
-                        }
-                        .resizable()
-                        .aspectRatio(contentMode: .fit)
-                        .frame(width: 120, height: 160)
-                        .background(.regularMaterial)
-                        .clipShape(RoundedRectangle(cornerRadius: 8))
+                    BookImageView(imageURL: book.displayImageSource) {
+                        Image(systemName: "book.closed")
+                            .foregroundStyle(.secondary)
+                            .font(.system(size: 48))
+                    }
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: 120, height: 160)
+                    .background(.regularMaterial)
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
                     
                     Spacer()
                 }

--- a/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookFormView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookFormView.swift
@@ -241,8 +241,8 @@ public struct BookFormView<AutoFillButton: View>: View {
             HStack {
                 Spacer()
                 
-                if let thumbnailURL = book.thumbnail ?? book.smallThumbnail {
-                    BookImageView(imageURL: thumbnailURL) {
+                if let imageSource = book.displayImageSource {
+                    BookImageView(imageURL: imageSource) {
                         Image(systemName: "book.closed")
                             .foregroundStyle(.secondary)
                             .font(.system(size: 40))

--- a/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookImageView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookImageView.swift
@@ -1,13 +1,8 @@
 import Kingfisher
-import PictureBookLendingDomain
 import SwiftUI
 
-#if canImport(UIKit)
-    import UIKit
-#endif
-
 /// 絵本画像表示用のビュー
-/// ローカル画像とリモート画像の両方に対応
+/// KFImageを使ってローカル画像とリモート画像の両方に対応
 public struct BookImageView<PlaceholderContent: View>: View {
     let imageURL: String?
     let placeholder: PlaceholderContent
@@ -21,51 +16,13 @@ public struct BookImageView<PlaceholderContent: View>: View {
     }
     
     public var body: some View {
-        Group {
-            if let imageURL = imageURL {
-                if isLocalImagePath(imageURL) {
-                    // ローカル画像の表示
-                    #if canImport(UIKit)
-                        if let localImage = loadLocalImage(from: imageURL) {
-                            Image(uiImage: localImage)
-                                .resizable()
-                        } else {
-                            placeholder
-                        }
-                    #else
-                        placeholder
-                    #endif
-                } else {
-                    // リモート画像の表示（従来のKingfisher）
-                    KFImage(URL(string: imageURL))
-                        .placeholder {
-                            placeholder
-                        }
-                        .resizable()
-                }
-            } else {
+        KFImage(URL(string: imageURL ?? ""))
+            .placeholder {
                 placeholder
             }
-        }
+            .resizable()
     }
     
-    /// ローカル画像パスかどうかを判定
-    private func isLocalImagePath(_ path: String) -> Bool {
-        guard let url = URL(string: path) else { return false }
-        return url.scheme == "file"
-    }
-    
-    /// ローカル画像を読み込む
-    #if canImport(UIKit)
-        private func loadLocalImage(from path: String) -> UIImage? {
-            guard let url = URL(string: path) else { return nil }
-            return UIImage(contentsOfFile: url.path)
-        }
-    #else
-        private func loadLocalImage(from path: String) -> NSImage? {
-            return nil
-        }
-    #endif
 }
 
 #Preview {

--- a/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookListView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookListView.swift
@@ -242,7 +242,7 @@ public struct BookRowView<RowAction: View>: View {
     public var body: some View {
         HStack {
             // サムネイル画像
-            BookImageView(imageURL: book.smallThumbnail ?? book.thumbnail) {
+            BookImageView(imageURL: book.displaySmallImageSource) {
                 Image(systemName: "book.closed")
                     .foregroundStyle(.secondary)
                     .font(.title2)

--- a/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookSearchResultsView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookSearchResultsView.swift
@@ -65,17 +65,15 @@ public struct BookSearchResultRowView: View {
     public var body: some View {
         HStack {
             // サムネイル画像
-            KFImage(URL(string: scoredBook.book.thumbnail ?? scoredBook.book.smallThumbnail ?? ""))
-                .placeholder {
-                    Image(systemName: "book.closed")
-                        .foregroundStyle(.secondary)
-                        .font(.title2)
-                }
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .frame(width: 60, height: 80)
-                .background(.regularMaterial)
-                .clipShape(RoundedRectangle(cornerRadius: 6))
+            BookImageView(imageURL: scoredBook.book.displayImageSource) {
+                Image(systemName: "book.closed")
+                    .foregroundStyle(.secondary)
+                    .font(.title2)
+            }
+            .aspectRatio(contentMode: .fit)
+            .frame(width: 60, height: 80)
+            .background(.regularMaterial)
+            .clipShape(RoundedRectangle(cornerRadius: 6))
             
             VStack(alignment: .leading, spacing: 4) {
                 Text(scoredBook.book.title)

--- a/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookSearchView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookSearchView.swift
@@ -327,15 +327,11 @@ struct SearchResultRow: View {
         Button(action: onTap) {
             HStack {
                 // サムネイル画像
-                KFImage(
-                    URL(string: scoredBook.book.thumbnail ?? scoredBook.book.smallThumbnail ?? "")
-                )
-                .placeholder {
+                BookImageView(imageURL: scoredBook.book.displayImageSource) {
                     Image(systemName: "book.closed")
                         .foregroundStyle(.secondary)
                         .font(.title2)
                 }
-                .resizable()
                 .aspectRatio(contentMode: .fit)
                 .frame(width: 60, height: 80)
                 .background(.regularMaterial)


### PR DESCRIPTION
## Summary

TestFlightアップデート後に画像が表示されなくなる問題を修正しました。

- **根本原因**: ImageStorageUtilityが絶対パス（コンテナIDを含む）を保存していたため、TestFlightアップデート時にコンテナIDが変更され、画像パスが無効になっていました
- **解決策**: ファイル名のみを保存し、表示時に動的にパスを構築する方式に変更しました
- **後方互換性**: SwiftDataマイグレーション（V1.1→V1.2）で既存の絶対パスからファイル名を抽出し、新しいスキーマに移行

## 主な変更

### ドメイン層 (PictureBookLendingDomain)
- **Book構造体**: `localImageFileName`フィールドを追加
- **表示用メソッド**: `displayImageSource`と`displaySmallImageSource`を追加し、ローカル・リモート画像の統一的な取得を実現

### インフラ層 (PictureBookLendingInfrastructure) 
- **ImageStorageUtility**: `saveImage()`の戻り値を絶対パスからファイル名のみに変更
- **SwiftDataスキーマ**: V1.2に更新し、`localImageFileName`フィールドを追加
- **マイグレーション**: V1.1からV1.2への自動移行処理を実装

### UI層 (PictureBookLendingUI)
- **BookImageView**: KFImageによる統一処理に簡素化
- **各Viewコンポーネント**: `displayImageSource`を使用するように更新

## 技術詳細

**Before** (問題のあった実装):
```swift
// 絶対パスを保存（コンテナIDが含まれる）
let absolutePath = "file:///var/mobile/Containers/.../image.jpg"
book.thumbnail = absolutePath
```

**After** (修正後の実装):
```swift
// ファイル名のみ保存
let fileName = "12345678-1234-1234-1234-123456789012.jpg" 
book.localImageFileName = fileName

// 表示時に動的にパス構築
public var displayImageSource: String? {
    if let localImageFileName = localImageFileName {
        let documentsURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
        let imageDirectoryURL = documentsURL.appendingPathComponent("BookImages")
        let fileURL = imageDirectoryURL.appendingPathComponent(localImageFileName)
        return fileURL.absoluteString
    }
    return thumbnail ?? smallThumbnail
}
```

## Test plan

- [x] プロジェクト全体のビルドが成功することを確認
- [x] 新規画像保存時にファイル名のみが保存されることを確認
- [x] 既存の絶対パス形式の画像がマイグレーション後に正常に表示されることを確認  
- [x] ローカル画像とリモート画像の両方が正常に表示されることを確認
- [x] KFImageでfile://スキーマのローカル画像が正常に読み込まれることを確認
- [ ] TestFlightでアップデート前後の画像表示動作を確認

🤖 Generated with [Claude Code](https://claude.ai/code)