### PR TITLE
fix: searchable二重定義とデバッグコードを除去

### DIFF
--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Loan/LoanActionContainerButton.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Loan/LoanActionContainerButton.swift
@@ -43,7 +43,6 @@ struct LoanActionContainerButton: View {
     }
     
     var body: some View {
-        let _ = Self._printChanges()
         VStack {
             if isBookLent {
                 ReturnButtonView(onTap: handleReturnTap)
@@ -69,11 +68,6 @@ struct LoanActionContainerButton: View {
                 }
             }
         }
-        //        .alert(alertState.title, isPresented: $alertState.isPresented) {
-        //            Button("OK", role: .cancel) {}
-        //        } message: {
-        //            Text(alertState.message)
-        //        }
     }
     
     // MARK: - Actions

--- a/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookListView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookListView.swift
@@ -105,16 +105,6 @@ public struct BookListView<RowAction: View>: View {
                 bookListSection
             }
         }
-        #if os(iOS)
-            .searchable(
-                text: $searchText,
-                placement: .navigationBarDrawer(displayMode: .always),
-                prompt: "絵本のタイトルまたは著者で検索")
-        #else
-            .searchable(
-                text: $searchText,
-                prompt: "絵本のタイトルまたは著者で検索")
-        #endif
     }
     
     // MARK: - Private Views


### PR DESCRIPTION
## 概要

`.searchable` モディファイアの二重定義の解消と、デバッグ用コードのクリーンアップを行います。

## 変更内容

### 1. `.searchable` 二重定義の解消
- `BookListContainerView`（Container側）と `BookListView`（Presentation側）の両方に同一の `.searchable` が定義されていたため、Presentation側（`BookListView`）の定義を削除
- プロジェクトの Container/Presentation 分離方針（NavigationStack・alert・sheet 等の画面制御は Container 側が担当）に準拠

### 2. `LoanActionContainerButton` のクリーンアップ
- デバッグ用の `let _ = Self._printChanges()` を削除
- コメントアウトされたまま残っていた alert コードを削除

## 補足

`.searchable` の二重定義は、検索バーが二重に表示される・検索フィールドのフォーカスやソートメニュー操作時に表示が不安定になるなどの症状の原因候補であり、issue #143「ソート機能時にでない」の原因候補と考えられます（Refs #143）。

## 検証

- `swift format lint`（PictureBookLendingUI / PictureBookLendingAdmin）: 警告なし
- `swift build`（PictureBookLendingUI）: 成功
- `swift test`: Model 41件 / Infrastructure 38件 / UI すべて成功（Domain の `LoanSettingsTests.testDefaultSettings` 1件失敗は origin/main 由来の既存失敗で本変更とは無関係）
- `xcodebuild build` はローカル環境の iOS 26.5 SDK と Simulator ランタイム不一致（actool エラー）により origin/main 時点でも失敗するため検証不可

🤖 Generated with [Claude Code](https://claude.com/claude-code)