### PR TITLE
fix: LoanSettingsTestsのデフォルト貸出期間の期待値を実装に合わせ修正

### DIFF
--- a/PictureBookLendingAdminApp/PictureBookLendingDomain/Tests/PictureBookLendingDomainTests/LoanSettingsTests.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingDomain/Tests/PictureBookLendingDomainTests/LoanSettingsTests.swift
@@ -8,7 +8,7 @@ final class LoanSettingsTests: XCTestCase {
         // デフォルト設定のテスト
         let defaultSettings = LoanSettings.default
         
-        XCTAssertEqual(defaultSettings.defaultLoanPeriodDays, 14)
+        XCTAssertEqual(defaultSettings.defaultLoanPeriodDays, 7)
         XCTAssertTrue(defaultSettings.isValid())
     }
     


### PR DESCRIPTION
## 概要

origin/main で Domainパッケージの単体テスト `LoanSettingsTests.testDefaultSettings` が1件失敗していたため修正しました。

## 原因

2eda058（2025-08-15「refactor: LoanSettingsから保護者関連設定を削除し、UIでローカル管理に変更」）で `LoanSettings.default` の貸出期間が意図的に 14日 → 7日 へ変更された際、テストの期待値が更新されていませんでした。

## 対応

実装側（7日）を正とし、テストの期待値を `14` → `7` に修正（1行）。

## 検証

`cd PictureBookLendingAdminApp/PictureBookLendingDomain && swift test` で全テスト成功を確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)