### PR TITLE
feat: 貸出・返却の成功フィードバックをアラートからチェック演出に変更

### DIFF
--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/BookDetailContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/BookDetailContainerView.swift
@@ -14,6 +14,7 @@ struct BookDetailContainerView: View {
     
     @State private var book: Book
     @State private var alertState = AlertState()
+    @State private var successFeedback = SuccessFeedback()
     
     init(book: Book) {
         self._book = State(initialValue: book)
@@ -25,7 +26,8 @@ struct BookDetailContainerView: View {
             currentLoan: currentLoan,
             loanHistory: loanHistory,
         ) {
-            LoanActionContainerButton(bookId: book.id, alertState: $alertState)
+            LoanActionContainerButton(
+                bookId: book.id, alertState: $alertState, successFeedback: $successFeedback)
         }
         .navigationTitle(book.title)
         #if os(iOS)
@@ -36,6 +38,7 @@ struct BookDetailContainerView: View {
         } message: {
             Text(alertState.message)
         }
+        .successFeedback($successFeedback)
         .onChange(of: book) { _, newValue in
             do {
                 _ = try bookModel.updateBook(newValue)

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/BookListContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/BookListContainerView.swift
@@ -19,6 +19,7 @@ struct BookListContainerView: View {
     @State private var isBulkAddSheetPresented = false
     @State private var editingBook: Book?
     @State private var alertState = AlertState()
+    @State private var successFeedback = SuccessFeedback()
     @State private var selectedKanaFilter: KanaGroup?
     @State private var selectedSortType: BookSortType = .title
     /// 五十音グループでセクション化された全絵本データ（フィルタリング・ソート前のベース）
@@ -40,7 +41,8 @@ struct BookListContainerView: View {
             if isEditMode {
                 BookStatusView(isCurrentlyLent: loanModel.isBookLent(bookId: book.id))
             } else {
-                LoanActionContainerButton(bookId: book.id, alertState: $alertState)
+                LoanActionContainerButton(
+                    bookId: book.id, alertState: $alertState, successFeedback: $successFeedback)
             }
         }
         #if os(iOS)
@@ -81,6 +83,7 @@ struct BookListContainerView: View {
         } message: {
             Text(alertState.message)
         }
+        .successFeedback($successFeedback)
         .onChange(of: bookModel.books) {
             loadBookSections()
         }

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Loan/LoanActionContainerButton.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Loan/LoanActionContainerButton.swift
@@ -23,8 +23,10 @@ struct LoanActionContainerButton: View {
     @State private var isLoanSheetPresented = false
     /// 返却確認アラートの表示状態
     @State private var isReturnConfirmationPresented = false
-    /// アラート状態管理
+    /// アラート状態管理（エラー表示用）
     @Binding var alertState: AlertState
+    /// 成功フィードバック状態管理
+    @Binding var successFeedback: SuccessFeedback
     
     /// bookIdから取得した絵本オブジェクト
     private var book: Book? {
@@ -52,7 +54,7 @@ struct LoanActionContainerButton: View {
         }
         .sheet(isPresented: $isLoanSheetPresented) {
             if let book = book {
-                LoanFormContainerView(selectedBook: book)
+                LoanFormContainerView(selectedBook: book, onLoanSuccess: handleLoanSuccess)
                     .interactiveDismissDisabled()  // スワイプで閉じないようにする
             }
         }
@@ -82,11 +84,16 @@ struct LoanActionContainerButton: View {
         isReturnConfirmationPresented = true
     }
     
+    /// 貸出成功時の処理
+    private func handleLoanSuccess(userName: String) {
+        successFeedback.show("\(userName)さんに貸出しました")
+    }
+    
     /// 返却処理の実行
     private func performReturn() {
         do {
             try loanModel.returnBook(bookId: bookId)
-            alertState = .success("返却が完了しました")
+            successFeedback.show("返却しました")
         } catch {
             alertState = .error("返却処理に失敗しました", message: error.localizedDescription)
         }
@@ -96,6 +103,7 @@ struct LoanActionContainerButton: View {
 #Preview {
     
     @Previewable @State var alertState = AlertState()
+    @Previewable @State var successFeedback = SuccessFeedback()
     
     let mockRepositoryFactory = MockRepositoryFactory()
     let bookModel = BookModel(repository: mockRepositoryFactory.bookRepository)
@@ -111,7 +119,8 @@ struct LoanActionContainerButton: View {
     let sampleBook = Book(title: "はらぺこあおむし", author: "エリック・カール", managementNumber: "あ001")
     
     VStack(spacing: 16) {
-        LoanActionContainerButton(bookId: sampleBook.id, alertState: $alertState)
+        LoanActionContainerButton(
+            bookId: sampleBook.id, alertState: $alertState, successFeedback: $successFeedback)
         
         // リスト内での表示例
         List {
@@ -126,7 +135,9 @@ struct LoanActionContainerButton: View {
                 
                 Spacer()
                 
-                LoanActionContainerButton(bookId: sampleBook.id, alertState: $alertState)
+                LoanActionContainerButton(
+                    bookId: sampleBook.id, alertState: $alertState,
+                    successFeedback: $successFeedback)
             }
             .padding(.vertical, 4)
         }

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Loan/LoanFormContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Loan/LoanFormContainerView.swift
@@ -16,8 +16,6 @@ struct LoanFormContainerView: View {
     @Environment(LoanSettingsModel.self) private var loanSettingModel
     @Environment(\.dismiss) private var dismiss
     
-    /// 選択した絵本
-    let selectedBook: Book
     /// 選択したクラス（組）
     @State private var selectedClassGroup: ClassGroup?
     /// 選択した利用者
@@ -25,6 +23,11 @@ struct LoanFormContainerView: View {
     /// 利用者種別選択（デフォルトは園児）
     @State private var selectedUserTypeCategory: UserTypeCategory = .child
     @State private var alertState = AlertState()
+    
+    /// 選択した絵本
+    let selectedBook: Book
+    /// 貸出成功時の動作（貸出先の利用者名を渡す）
+    let onLoanSuccess: (String) -> Void
     
     var body: some View {
         NavigationStack {
@@ -75,13 +78,7 @@ struct LoanFormContainerView: View {
                 #endif
             }
             .alert(alertState.title, isPresented: $alertState.isPresented) {
-                if alertState.type == .success {
-                    Button("OK", role: .cancel) {
-                        dismiss()  // 成功時は画面を閉じる
-                    }
-                } else {
-                    Button("OK", role: .cancel) {}
-                }
+                Button("OK", role: .cancel) {}
             } message: {
                 Text(alertState.message)
             }
@@ -143,7 +140,8 @@ struct LoanFormContainerView: View {
             }
             
             _ = try loanModel.lendBook(bookId: selectedBook.id, userId: user.id)
-            alertState = .success("貸出登録が完了しました")
+            onLoanSuccess(user.name)
+            dismiss()
         } catch {
             alertState = .error("貸出登録に失敗しました", message: "\(error.localizedDescription)")
         }
@@ -171,7 +169,7 @@ struct LoanFormContainerView: View {
     
     let selectedBook = Book(title: "りんごかもしれない", author: "ヨシタケ・シンスケ", managementNumber: "え001")
     
-    LoanFormContainerView(selectedBook: selectedBook)
+    LoanFormContainerView(selectedBook: selectedBook, onLoanSuccess: { _ in })
         .environment(userModel)
         .environment(loanModel)
         .environment(classGroupModel)

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Loan/LoanListContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Loan/LoanListContainerView.swift
@@ -19,6 +19,8 @@ struct LoanListContainerView: View {
     @State private var isSettingsPresented = false
     /// アラート状態
     @State private var alertState = AlertState()
+    /// 成功フィードバック状態
+    @State private var successFeedback = SuccessFeedback()
     
     var body: some View {
         LoanListView(
@@ -26,7 +28,8 @@ struct LoanListContainerView: View {
             selectedGroupFilter: $selectedGroupFilter,
             groupFilterOptions: groupFilterOptions
         ) { loan in
-            LoanActionContainerButton(bookId: loan.bookId, alertState: $alertState)
+            LoanActionContainerButton(
+                bookId: loan.bookId, alertState: $alertState, successFeedback: $successFeedback)
         }
         .navigationTitle("貸出管理")
         .toolbar {
@@ -53,6 +56,7 @@ struct LoanListContainerView: View {
         } message: {
             Text(alertState.message)
         }
+        .successFeedback($successFeedback)
         .onAppear {
             selectedGroupFilter = nil  // フィルターリセット
             refreshData()

--- a/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Views/SuccessFeedbackView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Views/SuccessFeedbackView.swift
@@ -3,10 +3,18 @@ import SwiftUI
 /// 成功フィードバックの表示状態
 ///
 /// OKタップ不要の成功フィードバック（チェックマーク表示＋ハプティクス）を制御します。
-/// `occurrenceCount` は連続表示時にハプティクスと自動消滅タイマーを再起動させるためのトリガです。
 public struct SuccessFeedback: Equatable, Sendable {
+    /// フィードバックが表示中かどうか
     public var isPresented: Bool
+    /// 表示するメッセージ（例：「○○さんに貸出しました」）
     public var message: String
+    /// `show(_:)` が呼ばれた累計回数
+    ///
+    /// SwiftUIは「値の変化」しか検知できないため、表示中にもう一度 `show(_:)` を
+    /// 呼んでも `isPresented`（true→true）では再表示を検知できない。
+    /// この値を `sensoryFeedback` と `task(id:)` のトリガに渡すことで、
+    /// 連続操作時にも毎回ハプティクスが鳴り、自動消滅タイマーが新しい表示の
+    /// タイミングから再スタートする。
     public private(set) var occurrenceCount: Int
     
     public init() {

--- a/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Views/SuccessFeedbackView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Views/SuccessFeedbackView.swift
@@ -1,0 +1,124 @@
+import SwiftUI
+
+/// 成功フィードバックの表示状態
+///
+/// OKタップ不要の成功フィードバック（チェックマーク表示＋ハプティクス）を制御します。
+/// `occurrenceCount` は連続表示時にハプティクスと自動消滅タイマーを再起動させるためのトリガです。
+public struct SuccessFeedback: Equatable, Sendable {
+    public var isPresented: Bool
+    public var message: String
+    public private(set) var occurrenceCount: Int
+    
+    public init() {
+        self.isPresented = false
+        self.message = ""
+        self.occurrenceCount = 0
+    }
+    
+    /// 成功フィードバックを表示する
+    public mutating func show(_ message: String) {
+        self.message = message
+        isPresented = true
+        occurrenceCount += 1
+    }
+    
+    /// 成功フィードバックを非表示にする
+    public mutating func dismiss() {
+        isPresented = false
+    }
+}
+
+/// 成功フィードバックのPresentation View
+///
+/// チェックマークとメッセージを表示します。
+/// 操作を妨げないよう、タップは透過します。
+public struct SuccessFeedbackView: View {
+    let message: String
+    
+    private enum Layout {
+        static let iconSize: CGFloat = 64
+        static let spacing: CGFloat = 12
+        static let padding: CGFloat = 32
+        static let cornerRadius: CGFloat = 20
+    }
+    
+    public init(message: String) {
+        self.message = message
+    }
+    
+    public var body: some View {
+        VStack(spacing: Layout.spacing) {
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: Layout.iconSize))
+                .foregroundStyle(.green)
+            
+            Text(message)
+                .font(.headline)
+                .multilineTextAlignment(.center)
+        }
+        .padding(Layout.padding)
+        .background(
+            .regularMaterial,
+            in: RoundedRectangle(cornerRadius: Layout.cornerRadius)
+        )
+        .allowsHitTesting(false)
+    }
+}
+
+/// 成功フィードバックを画面中央にオーバーレイ表示するModifier
+///
+/// 表示後は自動で消滅し、表示時に成功ハプティクスを発生させます。
+/// OKタップは不要で、操作をブロックしません。
+private struct SuccessFeedbackModifier: ViewModifier {
+    @Binding var feedback: SuccessFeedback
+    
+    private enum Constants {
+        /// 自動消滅までの表示時間（DESIGN_PRINCIPLES.md「フィードバック設計」準拠）
+        static let displayDuration: Duration = .seconds(1.5)
+        /// 出現・消滅アニメーションの時間
+        static let transitionDuration: TimeInterval = 0.3
+        /// 出現時の初期スケール
+        static let initialScale: CGFloat = 0.8
+    }
+    
+    func body(content: Content) -> some View {
+        content
+            .overlay {
+                if feedback.isPresented {
+                    SuccessFeedbackView(message: feedback.message)
+                        .transition(
+                            .scale(scale: Constants.initialScale).combined(with: .opacity))
+                }
+            }
+            .animation(
+                .spring(duration: Constants.transitionDuration), value: feedback.isPresented
+            )
+            .sensoryFeedback(.success, trigger: feedback.occurrenceCount)
+            .task(id: feedback.occurrenceCount) {
+                guard feedback.isPresented else { return }
+                try? await Task.sleep(for: Constants.displayDuration)
+                feedback.dismiss()
+            }
+    }
+}
+
+extension View {
+    /// 成功フィードバック（チェックマーク＋ハプティクス、自動消滅）をオーバーレイ表示する
+    public func successFeedback(_ feedback: Binding<SuccessFeedback>) -> some View {
+        modifier(SuccessFeedbackModifier(feedback: feedback))
+    }
+}
+
+#Preview {
+    @Previewable @State var feedback = SuccessFeedback()
+    
+    List {
+        Button("貸出成功") {
+            feedback.show("山田太郎さんに貸出しました")
+        }
+        Button("返却成功") {
+            feedback.show("返却しました")
+        }
+    }
+    .successFeedback($feedback)
+}

--- a/PictureBookLendingAdminApp/PictureBookLendingUI/Tests/PictureBookLendingUITests/SuccessFeedbackTests.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingUI/Tests/PictureBookLendingUITests/SuccessFeedbackTests.swift
@@ -1,0 +1,57 @@
+import XCTest
+
+@testable import PictureBookLendingUI
+
+final class SuccessFeedbackTests: XCTestCase {
+    
+    func testInitialState() {
+        let feedback = SuccessFeedback()
+        
+        XCTAssertFalse(feedback.isPresented)
+        XCTAssertEqual(feedback.message, "")
+        XCTAssertEqual(feedback.occurrenceCount, 0)
+    }
+    
+    func testShowPresentsMessage() {
+        var feedback = SuccessFeedback()
+        
+        feedback.show("返却しました")
+        
+        XCTAssertTrue(feedback.isPresented)
+        XCTAssertEqual(feedback.message, "返却しました")
+        XCTAssertEqual(feedback.occurrenceCount, 1)
+    }
+    
+    func testDismissHidesButKeepsMessage() {
+        var feedback = SuccessFeedback()
+        feedback.show("返却しました")
+        
+        feedback.dismiss()
+        
+        XCTAssertFalse(feedback.isPresented)
+        XCTAssertEqual(feedback.message, "返却しました")
+        XCTAssertEqual(feedback.occurrenceCount, 1)
+    }
+    
+    func testConsecutiveShowsIncrementOccurrenceCount() {
+        var feedback = SuccessFeedback()
+        
+        feedback.show("山田太郎さんに貸出しました")
+        feedback.show("鈴木花子さんに貸出しました")
+        
+        XCTAssertTrue(feedback.isPresented)
+        XCTAssertEqual(feedback.message, "鈴木花子さんに貸出しました")
+        XCTAssertEqual(feedback.occurrenceCount, 2, "連続表示でもハプティクスとタイマーが再発火するようカウントが増える")
+    }
+    
+    func testShowAfterDismissPresentsAgain() {
+        var feedback = SuccessFeedback()
+        feedback.show("返却しました")
+        feedback.dismiss()
+        
+        feedback.show("山田太郎さんに貸出しました")
+        
+        XCTAssertTrue(feedback.isPresented)
+        XCTAssertEqual(feedback.occurrenceCount, 2)
+    }
+}


### PR DESCRIPTION
## 概要
Phase 1-①: 貸出・返却の成功時のOKボタン付きアラートを廃止し、チェックマーク表示（1.5秒自動消滅）＋成功ハプティクスに置換します。確認タップ0回で次の操作に移れます。

[docs/DESIGN_PRINCIPLES.md](https://github.com/takuyaaaaaaahaaaaaa/PictureBookLendingApp/blob/main/docs/DESIGN_PRINCIPLES.md) の「フィードバック設計」（成功は軽く・エラーは重く）準拠。

## 変更内容
- **UI層**: `SuccessFeedback` 状態 + `SuccessFeedbackView` + `.successFeedback(_:)` モディファイア（オーバーレイ・自動消滅・`sensoryFeedback(.success)`・タップ透過）を新規追加
- **貸出フロー**: 成功時はシートを即時クローズし、呼び出し元画面でチェック演出（「○○さんに貸出しました」）
- **返却フロー**: 成功アラート→チェック演出（「返却しました」）。確認ダイアログは維持（Undoスナックバー化は #38 で対応予定）
- **エラーアラートは従来どおり維持**
- ホスト3画面（絵本一覧・貸出管理・絵本詳細）に演出オーバーレイを設置
- `SuccessFeedback` の単体テスト5件追加

## テスト
- PictureBookLendingUI: `swift build` / `swift test` 成功（6件パス）
- アプリ全体: iOS 26.5 Simulatorランタイム未インストールのため、アセットカタログ除外でSwiftコンパイル検証のみ実施（環境起因・mainでも同様）

## 確認してほしいこと（実機で）
- [ ] チェック演出の表示時間1.5秒は長い？短い？
- [ ] ハプティクスの感触
- [ ] 連続で貸出・返却したときの演出の切り替わり
- [ ] 「○○さんに貸出しました」の文言（さん付け）

Refs #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)