### PR TITLE
refactor: ローカル画像パス解決をDomain層からApp層へ移動

### DIFF
--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Presentation/Book+ImageSource.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Presentation/Book+ImageSource.swift
@@ -1,0 +1,24 @@
+import PictureBookLendingDomain
+import PictureBookLendingInfrastructure
+
+extension Book {
+    /// 表示用の画像URLを取得する（ローカル画像優先）
+    /// ローカル保存画像が存在する場合はそのファイルURLを返し、そうでなければ外部URLのサムネイルを返す
+    /// - Returns: 画像のURL（存在しない場合はnil）
+    var resolvedImageSource: String? {
+        if let localImageFileName {
+            return ImageStorageUtility.imageURL(for: localImageFileName).absoluteString
+        }
+        return displayImageSource
+    }
+    
+    /// 表示用の画像URLを取得する（ローカル画像優先、小さいサムネイル優先）
+    /// ローカル保存画像が存在する場合はそのファイルURLを返し、そうでなければ外部URLのサムネイルを返す
+    /// - Returns: 画像のURL（存在しない場合はnil）
+    var resolvedSmallImageSource: String? {
+        if let localImageFileName {
+            return ImageStorageUtility.imageURL(for: localImageFileName).absoluteString
+        }
+        return displaySmallImageSource
+    }
+}

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/BookDetailContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/BookDetailContainerView.swift
@@ -22,6 +22,7 @@ struct BookDetailContainerView: View {
     var body: some View {
         BookDetailView(
             book: $book,
+            imageURL: book.resolvedImageSource,
             currentLoan: currentLoan,
             loanHistory: loanHistory,
         ) {

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/BookFormContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/BookFormContainerView.swift
@@ -49,6 +49,7 @@ struct BookFormContainerView: View {
         NavigationStack {
             BookFormView(
                 book: $book,
+                imageURL: book.resolvedImageSource,
                 mode: mode,
                 autoFillButton: {
                     BookAutoFillContainerButton(

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/BookListContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/BookListContainerView.swift
@@ -35,7 +35,10 @@ struct BookListContainerView: View {
             selectedSortType: $selectedSortType,
             isEditMode: isEditMode,
             onEdit: handleEditBook,
-            onDelete: handleDeleteBook
+            onDelete: handleDeleteBook,
+            imageURLProvider: { book in
+                book.resolvedSmallImageSource
+            }
         ) { book in
             if isEditMode {
                 BookStatusView(isCurrentlyLent: loanModel.isBookLent(bookId: book.id))

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/SettingsBookListContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/SettingsBookListContainerView.swift
@@ -30,7 +30,10 @@ struct SettingsBookListContainerView: View {
             selectedSortType: $selectedSortType,
             isEditMode: isEditMode,
             onEdit: handleEditBook,
-            onDelete: handleDeleteBook
+            onDelete: handleDeleteBook,
+            imageURLProvider: { book in
+                book.resolvedSmallImageSource
+            }
         ) { book in
             BookStatusView(isCurrentlyLent: loanModel.isBookLent(bookId: book.id))
         }

--- a/PictureBookLendingAdminApp/PictureBookLendingDomain/Sources/PictureBookLendingDomain/Domain/Book.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingDomain/Sources/PictureBookLendingDomain/Domain/Book.swift
@@ -85,37 +85,17 @@ public struct Book: Identifiable, Codable, Hashable, Sendable {
         self.kanaGroup = kanaGroup
     }
     
-    /// 表示用の画像URLを取得する
-    /// ローカル画像が存在する場合はfile://付きフルパスを返し、そうでなければ外部URLを返す
+    /// 表示用の外部サムネイルURLを取得する
+    /// ローカル保存画像を含めた解決はApp層の `resolvedImageSource` が担当する
     /// - Returns: 画像のURL（存在しない場合はnil）
     public var displayImageSource: String? {
-        // ローカル画像が存在する場合は優先してfile://付きフルパスを返す
-        if let localImageFileName = localImageFileName {
-            let documentsURL = FileManager.default.urls(
-                for: .documentDirectory, in: .userDomainMask
-            ).first!
-            let imageDirectoryURL = documentsURL.appendingPathComponent("BookImages")
-            let fileURL = imageDirectoryURL.appendingPathComponent(localImageFileName)
-            return fileURL.absoluteString
-        }
-        // 外部URLのサムネイル
-        return thumbnail ?? smallThumbnail
+        thumbnail ?? smallThumbnail
     }
     
-    /// 表示用の画像URLを取得する（小さいサムネイル優先）
-    /// ローカル画像が存在する場合はfile://付きフルパスを返し、そうでなければ外部URLを返す
+    /// 表示用の外部サムネイルURLを取得する（小さいサムネイル優先）
+    /// ローカル保存画像を含めた解決はApp層の `resolvedSmallImageSource` が担当する
     /// - Returns: 画像のURL（存在しない場合はnil）
     public var displaySmallImageSource: String? {
-        // ローカル画像が存在する場合は優先してfile://付きフルパスを返す
-        if let localImageFileName = localImageFileName {
-            let documentsURL = FileManager.default.urls(
-                for: .documentDirectory, in: .userDomainMask
-            ).first!
-            let imageDirectoryURL = documentsURL.appendingPathComponent("BookImages")
-            let fileURL = imageDirectoryURL.appendingPathComponent(localImageFileName)
-            return fileURL.absoluteString
-        }
-        // 外部URLのサムネイル（小さいサイズ優先）
-        return smallThumbnail ?? thumbnail
+        smallThumbnail ?? thumbnail
     }
 }

--- a/PictureBookLendingAdminApp/PictureBookLendingInfrastructure/Sources/PictureBookLendingInfrastructure/Utilities/ImageStorageUtility.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingInfrastructure/Sources/PictureBookLendingInfrastructure/Utilities/ImageStorageUtility.swift
@@ -7,18 +7,26 @@ import Foundation
 /// 画像のローカル保存・読み込みを管理するユーティリティ
 public enum ImageStorageUtility {
     
+    /// 画像保存用のディレクトリ名
+    private static let imageDirectoryName = "BookImages"
+    
+    /// 画像保存用ディレクトリのURL
+    private static var imageDirectoryURL: URL {
+        let documentsURL = FileManager.default.urls(
+            for: .documentDirectory, in: .userDomainMask
+        ).first!
+        return documentsURL.appendingPathComponent(imageDirectoryName)
+    }
+    
+    /// ローカル保存された画像ファイル名から表示用のファイルURLを取得する
+    /// パスは呼び出し時に動的に構築する（アップデート時のコンテナID変更に対応）
+    /// - Parameter fileName: 保存済み画像のファイル名（拡張子付き）
+    /// - Returns: 画像ファイルのURL
+    public static func imageURL(for fileName: String) -> URL {
+        imageDirectoryURL.appendingPathComponent(fileName)
+    }
+    
     #if canImport(UIKit)
-        
-        /// 画像保存用のディレクトリ名
-        private static let imageDirectoryName = "BookImages"
-        
-        /// 画像保存用ディレクトリのURL
-        private static var imageDirectoryURL: URL {
-            let documentsURL = FileManager.default.urls(
-                for: .documentDirectory, in: .userDomainMask
-            ).first!
-            return documentsURL.appendingPathComponent(imageDirectoryName)
-        }
         
         /// 画像保存用ディレクトリを作成
         private static func createImageDirectoryIfNeeded() throws {

--- a/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookDetailView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookDetailView.swift
@@ -9,6 +9,8 @@ import SwiftUI
 public struct BookDetailView<ActionButton: View>: View {
     /// 表示・編集対象の絵本データ
     @Binding var book: Book
+    /// 表示用の画像URL（App層で解決済み）
+    let imageURL: String?
     /// 現在の貸出情報（貸出中の場合のみ存在）
     let currentLoan: Loan?
     /// 貸出履歴一覧
@@ -18,11 +20,13 @@ public struct BookDetailView<ActionButton: View>: View {
     
     public init(
         book: Binding<Book>,
+        imageURL: String? = nil,
         currentLoan: Loan? = nil,
         loanHistory: [Loan] = [],
         @ViewBuilder actionButton: @escaping () -> ActionButton
     ) {
         self._book = book
+        self.imageURL = imageURL
         self.currentLoan = currentLoan
         self.loanHistory = loanHistory
         self.actionButton = actionButton
@@ -34,7 +38,7 @@ public struct BookDetailView<ActionButton: View>: View {
                 HStack {
                     Spacer()
                     
-                    BookImageView(imageURL: book.displayImageSource) {
+                    BookImageView(imageURL: imageURL) {
                         Image(systemName: "book.closed")
                             .foregroundStyle(.secondary)
                             .font(.system(size: 48))

--- a/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookFormView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookFormView.swift
@@ -28,6 +28,7 @@ struct AutoFillTip: Tip {
 /// 画面制御はContainer Viewに委譲します。
 public struct BookFormView<AutoFillButton: View>: View {
     @Binding var book: Book
+    let imageURL: String?
     let mode: BookFormMode
     let autoFillButton: AutoFillButton?
     let onSave: () -> Void
@@ -39,6 +40,7 @@ public struct BookFormView<AutoFillButton: View>: View {
     
     public init(
         book: Binding<Book>,
+        imageURL: String? = nil,
         mode: BookFormMode,
         @ViewBuilder autoFillButton: () -> AutoFillButton,
         onSave: @escaping () -> Void,
@@ -47,6 +49,7 @@ public struct BookFormView<AutoFillButton: View>: View {
         onCameraTap: (() -> Void)? = nil
     ) {
         self._book = book
+        self.imageURL = imageURL
         self.mode = mode
         self.autoFillButton = autoFillButton()
         self.onSave = onSave
@@ -57,6 +60,7 @@ public struct BookFormView<AutoFillButton: View>: View {
     
     public init(
         book: Binding<Book>,
+        imageURL: String? = nil,
         mode: BookFormMode,
         onSave: @escaping () -> Void,
         onCancel: @escaping () -> Void,
@@ -64,6 +68,7 @@ public struct BookFormView<AutoFillButton: View>: View {
         onCameraTap: (() -> Void)? = nil
     ) where AutoFillButton == EmptyView {
         self._book = book
+        self.imageURL = imageURL
         self.mode = mode
         self.autoFillButton = nil
         self.onSave = onSave
@@ -241,7 +246,7 @@ public struct BookFormView<AutoFillButton: View>: View {
             HStack {
                 Spacer()
                 
-                if let imageSource = book.displayImageSource {
+                if let imageSource = imageURL {
                     BookImageView(imageURL: imageSource) {
                         Image(systemName: "book.closed")
                             .foregroundStyle(.secondary)

--- a/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookListView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/PictureBookLendingUI/Book/BookListView.swift
@@ -69,6 +69,8 @@ public struct BookListView<RowAction: View>: View {
     public let onEdit: (Book) -> Void
     /// 絵本削除時の動作
     public let onDelete: (Book) -> Void
+    /// 絵本のサムネイル画像URLを解決するクロージャ（App層で解決済みのURLを返す）
+    public let imageURLProvider: (Book) -> String?
     /// 各行に表示するアクションビューを生成するクロージャ
     public let rowAction: (Book) -> RowAction
     
@@ -82,6 +84,7 @@ public struct BookListView<RowAction: View>: View {
         isEditMode: Bool = false,
         onEdit: @escaping (Book) -> Void,
         onDelete: @escaping (Book) -> Void,
+        imageURLProvider: @escaping (Book) -> String?,
         @ViewBuilder rowAction: @escaping (Book) -> RowAction
     ) {
         self.sections = sections
@@ -92,6 +95,7 @@ public struct BookListView<RowAction: View>: View {
         self.isEditMode = isEditMode
         self.onEdit = onEdit
         self.onDelete = onDelete
+        self.imageURLProvider = imageURLProvider
         self.rowAction = rowAction
     }
     
@@ -211,12 +215,12 @@ public struct BookListView<RowAction: View>: View {
             Button {
                 onEdit(book)
             } label: {
-                BookRowView(book: book, rowAction: rowAction)
+                BookRowView(book: book, imageURL: imageURLProvider(book), rowAction: rowAction)
             }
             .buttonStyle(.plain)
         } else {
             NavigationLink(value: book) {
-                BookRowView(book: book, rowAction: rowAction)
+                BookRowView(book: book, imageURL: imageURLProvider(book), rowAction: rowAction)
             }
         }
     }
@@ -227,12 +231,13 @@ public struct BookListView<RowAction: View>: View {
 /// 一覧の各行に表示する絵本情報のレイアウトを定義します。
 public struct BookRowView<RowAction: View>: View {
     let book: Book
+    let imageURL: String?
     let rowAction: (Book) -> RowAction
     
     public var body: some View {
         HStack {
             // サムネイル画像
-            BookImageView(imageURL: book.displaySmallImageSource) {
+            BookImageView(imageURL: imageURL) {
                 Image(systemName: "book.closed")
                     .foregroundStyle(.secondary)
                     .font(.title2)
@@ -285,7 +290,10 @@ public struct BookRowView<RowAction: View>: View {
             selectedSortType: $selectedSortType,
             isEditMode: true,
             onEdit: { _ in },
-            onDelete: { _ in }
+            onDelete: { _ in },
+            imageURLProvider: { book in
+                book.displaySmallImageSource
+            }
         ) { book in
             LoanButtonView(onTap: {})
         }


### PR DESCRIPTION
## 概要

#140 と同じ目的のリファクタリングを、最新の main を起点に再実装したものです（#140 は古くなり、マージすると検索画面でローカル画像が壊れるためクローズ推奨）。

## 変更内容

- **Domain層**: `Book.displayImageSource` / `displaySmallImageSource` から `FileManager` 依存を排除し、外部URLサムネイルのみを返す純粋なプロパティに変更（「Domain層は純Swift」の方針に準拠）
- **Infrastructure層**: `ImageStorageUtility.imageURL(for:)` を追加し、ローカル画像のパス解決を一元化（パスは呼び出し時に動的構築するため、アップデート時のコンテナID変更にも安全）
- **App層**: `Presentation/Book+ImageSource.swift` を新設。`resolvedImageSource` / `resolvedSmallImageSource` でローカル画像を優先解決し、Containerから注入
- **UI層**: `BookDetailView` / `BookFormView` に `imageURL` パラメータ、`BookListView` に `imageURLProvider` クロージャを追加（Container/Presentation分離に準拠）

## #140 からの改善点

- パス組み立てをApp層に手書き複製せず `ImageStorageUtility` に集約
- #140 以後に追加された `BookSearchView` / `BookSearchResultsView` を考慮（外部API検索結果はローカル画像を持たないため変更不要と確認済み）
- `imageURLProvider` を `rowAction` の前に配置し、呼び出し側の trailing closure を維持

## テスト

- ✅ Domain (16) / Model (41) / Infrastructure (38) の全パッケージテストがパス
- ✅ Domain / Infrastructure / UI 各パッケージの `swift build` 成功
- ⚠️ ローカル環境に iOS 26.5 シミュレータランタイムがないため、アプリ全体ビルドはCIで検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)