### PR TITLE
refactor: ローカルパッケージ参照をFrameworksグループからルート直下へ移動

### DIFF
--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin.xcodeproj/project.pbxproj
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin.xcodeproj/project.pbxproj
@@ -169,10 +169,6 @@
 		EFDF91532DF0A0D6007EB46B /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				EFD9BABA2E20FDF300218826 /* PictureBookLendingDomain */,
-				EF6543052E225CC700D9B543 /* PictureBookLendingModel */,
-				EF6CC9272E21C2A10092EEDE /* PictureBookLendingInfrastructure */,
-				EF5A12492E210087000E665F /* PictureBookLendingUI */,
 				EF9609512E6757CB006A557F /* WidgetKit.framework */,
 				EF9609532E6757CB006A557F /* SwiftUI.framework */,
 			);
@@ -185,6 +181,10 @@
 				EFF77EF22DD66AAB009BD213 /* PictureBookLendingAdmin */,
 				EFF77F032DD66AAD009BD213 /* PictureBookLendingAdminTests */,
 				EF9609552E6757CB006A557F /* PictureBookLendingAdminWidget */,
+				EFD9BABA2E20FDF300218826 /* PictureBookLendingDomain */,
+				EF6543052E225CC700D9B543 /* PictureBookLendingModel */,
+				EF6CC9272E21C2A10092EEDE /* PictureBookLendingInfrastructure */,
+				EF5A12492E210087000E665F /* PictureBookLendingUI */,
 				EFF77EF12DD66AAB009BD213 /* Products */,
 				EFDF91532DF0A0D6007EB46B /* Frameworks */,
 				EF960A172E67C253006A557F /* PictureBookApp.icon */,


### PR DESCRIPTION
## 概要

Xcodeナビゲータの「Frameworks」グループに、ローカルSwiftパッケージ4つ（Domain / Model / Infrastructure / UI）の参照がシステムフレームワークと同居していたため、ルート直下へ移動しました。

## 変更内容

- `project.pbxproj` の PBXGroup のみ編集
- ローカルパッケージ4参照をルートグループ（アプリ系フォルダの下、Productsの上）へ移動
- 「Frameworks」グループには `WidgetKit.framework` / `SwiftUI.framework` のみが残る

## 影響範囲

ナビゲータ表示のみの変更です。リンクは `PBXFrameworksBuildPhase` と package product dependency で決まるため、ビルドへの影響はありません。

## 検証

- `plutil -lint` で pbxproj の構文OK
- `xcodebuild -list` でプロジェクトが正常に読み込まれ、ローカルパッケージ4つすべての解決を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)