### PR TITLE
feat: 延滞判定をDomainへ昇格し、家庭解決getFamilyMembersを追加

### DIFF
--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Loan/LoanListContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Loan/LoanListContainerView.swift
@@ -113,7 +113,7 @@ struct LoanListContainerView: View {
                 groupName: groupName,
                 loanDate: loan.loanDate,
                 dueDate: loan.dueDate,
-                isOverdue: loan.dueDate < Date()
+                isOverdue: loan.isOverdue(at: Date())
             )
         }
     }

--- a/PictureBookLendingAdminApp/PictureBookLendingDomain/Sources/Domain/Loan.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingDomain/Sources/Domain/Loan.swift
@@ -21,6 +21,15 @@ public struct Loan: Identifiable, Codable {
         returnedDate != nil
     }
     
+    /// 指定した日時の時点で延滞しているかどうか
+    ///
+    /// 未返却かつ返却期限を過ぎている場合に延滞とみなします（返却済みの貸出は延滞ではありません）。
+    /// - Parameter date: 判定基準の日時
+    /// - Returns: 延滞していればtrue
+    public func isOverdue(at date: Date) -> Bool {
+        !isReturned && dueDate < date
+    }
+    
     /// 貸出モデルの初期化
     /// - Parameters:
     ///   - id: 貸出の一意識別子（デフォルトでは新しいUUIDが生成されます）

--- a/PictureBookLendingAdminApp/PictureBookLendingDomain/Tests/LoanTests.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingDomain/Tests/LoanTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+
+@testable import PictureBookLendingDomain
+
+final class LoanTests: XCTestCase {
+    
+    private func makeLoan(dueDate: Date, returnedDate: Date? = nil) -> Loan {
+        Loan(
+            bookId: UUID(),
+            user: User(name: "いとう さくら", classGroupId: UUID()),
+            loanDate: dueDate.addingTimeInterval(-7 * 24 * 60 * 60),
+            dueDate: dueDate,
+            returnedDate: returnedDate
+        )
+    }
+    
+    func testIsOverdueBeforeDueDate() {
+        let dueDate = Date()
+        let loan = makeLoan(dueDate: dueDate)
+        
+        XCTAssertFalse(loan.isOverdue(at: dueDate.addingTimeInterval(-60)))
+    }
+    
+    func testIsOverdueAtExactDueDate() {
+        let dueDate = Date()
+        let loan = makeLoan(dueDate: dueDate)
+        
+        XCTAssertFalse(loan.isOverdue(at: dueDate), "期限ちょうどは延滞ではない")
+    }
+    
+    func testIsOverdueAfterDueDate() {
+        let dueDate = Date()
+        let loan = makeLoan(dueDate: dueDate)
+        
+        XCTAssertTrue(loan.isOverdue(at: dueDate.addingTimeInterval(60)))
+    }
+    
+    func testReturnedLoanIsNeverOverdue() {
+        let dueDate = Date()
+        let loan = makeLoan(dueDate: dueDate, returnedDate: dueDate.addingTimeInterval(120))
+        
+        XCTAssertFalse(loan.isOverdue(at: dueDate.addingTimeInterval(3600)), "返却済みの貸出は延滞ではない")
+    }
+}

--- a/PictureBookLendingAdminApp/PictureBookLendingModel/Sources/LoanModel.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingModel/Sources/LoanModel.swift
@@ -335,8 +335,7 @@ public class LoanModel {
     /// - Returns: 延滞している貸出件数
     public func getOverDueLoansCount(at today: Date) -> Int {
         getActiveLoans()
-            .filter { !$0.isReturned }  // 未返却
-            .filter { $0.dueDate < today }  // 返却期限が過ぎている
+            .filter { $0.isOverdue(at: today) }
             .count
     }
     

--- a/PictureBookLendingAdminApp/PictureBookLendingModel/Sources/UserModel.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingModel/Sources/UserModel.swift
@@ -123,6 +123,45 @@ public class UserModel {
         }
     }
     
+    /// 指定した利用者と同じ家庭の利用者一覧を取得する
+    ///
+    /// 園児と保護者は `UserType.guardian(relatedChildId:)` で紐づきます。
+    /// どの家族の利用者IDを渡しても同じ家庭に解決されます（先頭は園児、続いて保護者を名前順）。
+    /// 紐づく園児が見つからない保護者は本人のみを返します。
+    ///
+    /// - Parameter userId: 家庭を特定する利用者のID
+    /// - Returns: 家庭の利用者一覧（先頭は園児）。利用者が存在しない場合は空配列
+    public func getFamilyMembers(of userId: UUID) -> [User] {
+        guard let user = findUserById(userId) else { return [] }
+        
+        let childId: UUID
+        switch user.userType {
+        case .child:
+            childId = user.id
+        case .guardian(let relatedChildId):
+            childId = relatedChildId
+        }
+        
+        let allUsers = getAllUsers()
+        guard let child = allUsers.first(where: { $0.id == childId }) else {
+            // 正規操作では園児削除時に保護者もカスケード削除されるため到達しない。
+            // データ不整合時のフォールバックとして本人のみ返す
+            return [user]
+        }
+        
+        let guardians =
+            allUsers
+            .filter { member in
+                if case .guardian(let relatedChildId) = member.userType {
+                    return relatedChildId == childId
+                }
+                return false
+            }
+            .sorted { $0.name < $1.name }
+        
+        return [child] + guardians
+    }
+    
     /// 利用者情報を更新する
     ///
     /// 指定された利用者の情報を更新します。

--- a/PictureBookLendingAdminApp/PictureBookLendingModel/Tests/UserModelTests.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingModel/Tests/UserModelTests.swift
@@ -150,4 +150,92 @@ struct UserModelTests {
             try userModel.deleteUser(nonExistingId)
         }
     }
+    
+    // MARK: - 家庭解決（getFamilyMembers）
+    
+    /// 園児IDから家族全員（本人＋保護者）を取得できることのテスト
+    @Test("園児IDから家族全員を取得できることのテスト")
+    @MainActor
+    func getFamilyMembersFromChild() throws {
+        let (userModel, _) = createUserModel()
+        let classGroupId = UUID()
+        let child = try userModel.registerUser(User(name: "いとう さくら", classGroupId: classGroupId))
+        let mother = try userModel.registerUser(
+            User(
+                name: "伊藤 由美子", classGroupId: classGroupId,
+                userType: .guardian(relatedChildId: child.id)))
+        let father = try userModel.registerUser(
+            User(
+                name: "伊藤 健一", classGroupId: classGroupId,
+                userType: .guardian(relatedChildId: child.id)))
+        
+        let family = userModel.getFamilyMembers(of: child.id)
+        
+        #expect(family.count == 3)
+        #expect(family.first?.id == child.id, "園児が先頭に来る")
+        #expect(family.contains(where: { $0.id == mother.id }))
+        #expect(family.contains(where: { $0.id == father.id }))
+    }
+    
+    /// 保護者IDからも同じ家族に解決されることのテスト
+    @Test("保護者IDからも同じ家族に解決されることのテスト")
+    @MainActor
+    func getFamilyMembersFromGuardian() throws {
+        let (userModel, _) = createUserModel()
+        let classGroupId = UUID()
+        let child = try userModel.registerUser(User(name: "いとう さくら", classGroupId: classGroupId))
+        let mother = try userModel.registerUser(
+            User(
+                name: "伊藤 由美子", classGroupId: classGroupId,
+                userType: .guardian(relatedChildId: child.id)))
+        
+        let familyFromChild = userModel.getFamilyMembers(of: child.id)
+        let familyFromGuardian = userModel.getFamilyMembers(of: mother.id)
+        
+        #expect(familyFromChild.map(\.id) == familyFromGuardian.map(\.id), "どの家族名から入っても同じ家庭に着地する")
+    }
+    
+    /// 保護者が登録されていない園児は本人のみ返ることのテスト
+    @Test("保護者が未登録の園児は本人のみ返ることのテスト")
+    @MainActor
+    func getFamilyMembersChildOnly() throws {
+        let (userModel, _) = createUserModel()
+        let child = try userModel.registerUser(User(name: "あおき はると", classGroupId: UUID()))
+        
+        let family = userModel.getFamilyMembers(of: child.id)
+        
+        #expect(family.map(\.id) == [child.id])
+    }
+    
+    /// 存在しない利用者IDでは空配列が返ることのテスト
+    @Test("存在しない利用者IDでは空配列が返ることのテスト")
+    @MainActor
+    func getFamilyMembersUnknownId() {
+        let (userModel, _) = createUserModel()
+        
+        let family = userModel.getFamilyMembers(of: UUID())
+        
+        #expect(family.isEmpty)
+    }
+    
+    /// 園児を削除すると保護者もカスケード削除され、家庭解決が空になることのテスト
+    ///
+    /// `deleteUser` のドメイン仕様（園児削除で関連保護者も削除）により、
+    /// 「紐付く園児のいない保護者」は正規操作では発生しない。
+    @Test("園児削除で保護者も削除され家庭解決が空になることのテスト")
+    @MainActor
+    func getFamilyMembersAfterChildDeleted() throws {
+        let (userModel, _) = createUserModel()
+        let classGroupId = UUID()
+        let child = try userModel.registerUser(User(name: "いとう さくら", classGroupId: classGroupId))
+        let mother = try userModel.registerUser(
+            User(
+                name: "伊藤 由美子", classGroupId: classGroupId,
+                userType: .guardian(relatedChildId: child.id)))
+        
+        _ = try userModel.deleteUser(child.id)
+        
+        #expect(userModel.findUserById(mother.id) == nil, "園児削除で保護者もカスケード削除される（仕様）")
+        #expect(userModel.getFamilyMembers(of: mother.id).isEmpty)
+    }
 }


### PR DESCRIPTION
## 概要
Phase 2 段取り1の頭脳部分です（TDD）。**レビュー待ち——マージしません。**

### 1. `Loan.isOverdue(at:)`（Domain昇格）
「延滞とは未返却かつ返却期限超過」という業務ルールが `LoanModel.getOverDueLoansCount` と `LoanListContainerView` に重複実装されていたのをDomainに一本化（表示型ガイドライン=CLAUDE.md「業務判定はDomain/Modelへ」の適用第1号）。

- 期限ちょうどは延滞ではない／返却済みは延滞ではない、をテストで固定（4件）

### 2. `UserModel.getFamilyMembers(of:)`（家庭解決）
`guardian(relatedChildId:)` で家庭を解決。園児・保護者どちらのIDを渡しても同じ家庭（園児先頭＋保護者は名前順）に着地します——設計の「間違うドアがない」の実装基盤。

- テスト5件。うち「孤児の保護者」ケースは、`deleteUser` の**カスケード削除仕様**（園児削除で関連保護者も削除）により正規操作で発生しないことが判明したため、仕様準拠のテスト（削除後は家庭解決が空）に修正。実装の防御分岐はデータ不整合時のフォールバックとしてコメント付きで存置

## テスト
- PictureBookLendingDomain：10件 全パス
- PictureBookLendingModel：50件 全パス
- アプリ（シミュレータ向け）ビルド成功

## レビュー観点
- [ ] `isOverdue` の境界（期限ちょうど＝延滞でない）は業務感覚と合っているか
- [ ] 家庭解決の並び（園児先頭・保護者名前順）でよいか
- [ ] カスケード削除仕様への依存の妥当性

🤖 Generated with [Claude Code](https://claude.com/claude-code)