### PR TITLE
feat: 家庭の枠Containerと返却期限Formatterを追加（段取り1完成）

### DIFF
--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Presentation/Loan+Formatter.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Presentation/Loan+Formatter.swift
@@ -1,0 +1,17 @@
+import Foundation
+import PictureBookLendingDomain
+
+extension Loan {
+    /// 返却期限の表示文字列（例：「6月20日(土)」）
+    ///
+    /// 家庭の枠など主動線での表示用。年は省略し、月日と曜日のみを日本語で表示する。
+    var dueDateText: String {
+        dueDate.formatted(
+            .dateTime
+                .month()
+                .day()
+                .weekday()
+                .locale(Locale(identifier: "ja_JP"))
+        )
+    }
+}

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Family/FamilyLoanSlotsContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Family/FamilyLoanSlotsContainerView.swift
@@ -1,0 +1,138 @@
+import PictureBookLendingDomain
+import PictureBookLendingInfrastructure
+import PictureBookLendingModel
+import PictureBookLendingUI
+import SwiftUI
+
+/// 家庭の枠領域のContainer View
+///
+/// 利用者ID（園児・保護者どちらでも可）から家庭を解決し、
+/// 各枠の貸出状況を `FamilyLoanSlotsView` に供給します。
+/// 返却の実行とUndoフィードバックまでを担当し、
+/// 完了後の遷移（一覧へ戻る等）は呼び出し元に委ねます。
+struct FamilyLoanSlotsContainerView: View {
+    @Environment(UserModel.self) private var userModel
+    @Environment(LoanModel.self) private var loanModel
+    @Environment(BookModel.self) private var bookModel
+    
+    /// アラート状態管理（エラー表示用）
+    @Binding var alertState: AlertState
+    /// 返却のUndoフィードバック状態管理
+    @Binding var undoFeedback: UndoFeedback
+    
+    /// 家庭を特定する利用者ID（園児・保護者どちらでも可）
+    let userId: UUID
+    /// 文脈（返却／貸出）
+    let mode: FamilyLoanSlotsMode
+    /// 返却完了時の動作（一覧へ自動で戻る等は呼び出し元が決める）
+    let onReturnCompleted: () -> Void
+    /// 貸出文脈で枠が選ばれたときの動作（引数は枠の持ち主の利用者ID）
+    let onBorrowSlotSelected: (UUID) -> Void
+    
+    var body: some View {
+        FamilyLoanSlotsView(
+            slots: slots,
+            mode: mode,
+            onReturn: handleReturn(_:),
+            onBorrow: { onBorrowSlotSelected($0.id) }
+        )
+    }
+    
+    // MARK: - Computed Properties
+    
+    /// 家庭の全員分の枠表示データ
+    ///
+    /// 現状は1人1枠（maxBooksPerUser=1の運用前提）。複数冊設定時の枠の積み方は
+    /// SCREEN_DESIGN_PHASE2 §8 の未決事項として実装時に拡張する。
+    private var slots: [FamilyLoanSlotDisplay] {
+        userModel.getFamilyMembers(of: userId).map { member in
+            FamilyLoanSlotDisplay(
+                id: member.id,
+                roleLabel: Self.roleLabel(for: member),
+                memberName: member.name,
+                loan: loanDisplay(for: member)
+            )
+        }
+    }
+    
+    private static func roleLabel(for member: User) -> String {
+        switch member.userType.category {
+        case .child: "園児の本"
+        case .guardian: "保護者の本"
+        }
+    }
+    
+    private func loanDisplay(for member: User) -> FamilyLoanSlotLoan? {
+        guard let loan = loanModel.getUserActiveLoans(userId: member.id).first,
+            let book = bookModel.findBookById(loan.bookId)
+        else { return nil }
+        
+        return FamilyLoanSlotLoan(
+            bookTitle: book.title,
+            imageURL: book.resolvedSmallImageSource,
+            dueDateText: loan.dueDateText,
+            isOverdue: loan.isOverdue(at: Date())
+        )
+    }
+    
+    // MARK: - Actions
+    
+    /// 返却の実行（確認ダイアログなし・Undoカードでリカバリー）
+    private func handleReturn(_ slot: FamilyLoanSlotDisplay) {
+        guard let loan = loanModel.getUserActiveLoans(userId: slot.id).first else { return }
+        
+        do {
+            let returnedLoan = try loanModel.returnBook(loanId: loan.id)
+            let message =
+                if let title = bookModel.findBookById(returnedLoan.bookId)?.title {
+                    "『\(title)』を返却しました"
+                } else {
+                    "返却しました"
+                }
+            undoFeedback.show(message, targetId: returnedLoan.id)
+            onReturnCompleted()
+        } catch {
+            alertState = .error("返却処理に失敗しました", message: error.localizedDescription)
+        }
+    }
+}
+
+#Preview("返却文脈（実データ相当）") {
+    @Previewable @State var alertState = AlertState()
+    @Previewable @State var undoFeedback = UndoFeedback()
+    
+    let mockFactory = MockRepositoryFactory()
+    let bookModel = BookModel(repository: mockFactory.bookRepository)
+    let userModel = UserModel(repository: mockFactory.userRepository)
+    let loanModel = LoanModel(
+        repository: mockFactory.loanRepository,
+        bookRepository: mockFactory.bookRepository,
+        userRepository: mockFactory.userRepository,
+        loanSettingsRepository: mockFactory.loanSettingsRepository
+    )
+    
+    // 家庭（園児＋保護者）と貸出中の本をセットアップ
+    let child = try! userModel.registerUser(User(name: "いとう さくら", classGroupId: UUID()))
+    let mother = try! userModel.registerUser(
+        User(
+            name: "伊藤 由美子", classGroupId: child.classGroupId,
+            userType: .guardian(relatedChildId: child.id)))
+    let book = try! bookModel.registerBook(Book(title: "ぐりとぐら", author: "中川李枝子"))
+    _ = try! loanModel.lendBook(bookId: book.id, userId: child.id)
+    
+    return ScrollView {
+        FamilyLoanSlotsContainerView(
+            alertState: $alertState,
+            undoFeedback: $undoFeedback,
+            userId: mother.id,  // 保護者のIDから入っても同じ家庭に解決される
+            mode: .returning,
+            onReturnCompleted: {},
+            onBorrowSlotSelected: { _ in }
+        )
+        .padding()
+    }
+    .undoFeedback($undoFeedback, onUndo: {})
+    .environment(userModel)
+    .environment(loanModel)
+    .environment(bookModel)
+}

--- a/PictureBookLendingAdminApp/PictureBookLendingAdminTests/LoanFormatterTests.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdminTests/LoanFormatterTests.swift
@@ -1,0 +1,34 @@
+import PictureBookLendingDomain
+import XCTest
+
+@testable import PictureBookLendingAdmin
+
+final class LoanFormatterTests: XCTestCase {
+    
+    /// 2026年6月20日（土）12:00 JST の Date を生成する
+    private func makeDate() -> Date {
+        var components = DateComponents()
+        components.year = 2026
+        components.month = 6
+        components.day = 20
+        components.hour = 12
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "Asia/Tokyo")!
+        return calendar.date(from: components)!
+    }
+    
+    func testDueDateTextContainsMonthDayAndWeekday() {
+        let loan = Loan(
+            bookId: UUID(),
+            user: User(name: "いとう さくら", classGroupId: UUID()),
+            loanDate: makeDate().addingTimeInterval(-7 * 24 * 60 * 60),
+            dueDate: makeDate()
+        )
+        
+        let text = loan.dueDateText
+        
+        XCTAssertTrue(text.contains("6月20日"), "月日が日本語表記で含まれる: \(text)")
+        XCTAssertTrue(text.contains("土"), "曜日が含まれる: \(text)")
+        XCTAssertFalse(text.contains("2026"), "年は表示しない: \(text)")
+    }
+}


### PR DESCRIPTION
## 概要
Phase 2 段取り1の仕上げです。**レビュー待ち——マージしません。**

- **FamilyLoanSlotsContainerView（App層）**：`getFamilyMembers` で家庭を解決し、部品（FamilyLoanSlotsView）に表示データを供給。返却実行（確認なし＋Phase 1のUndoカード流用）まで担当。完了後の遷移（一覧へ戻る）は呼び出し元に委譲する設計で、段取り2（返却モードの名前一覧）がそのままホストできます
- **Loan+Formatter（Presentation）**：返却期限「6月20日(土)」形式（年なし）。+Formatter規約準拠・単体テスト付き
- 表示型ガイドライン準拠：Containerは整形と供給のみ、判定は `Loan.isOverdue(at:)`／`getFamilyMembers` に委譲

## テスト
- **`xcodebuild test` フルスイート成功**（Simulatorランタイム導入により全テスト実行が復活。Domain/Model/Infrastructure/UI/App全緑）
- Xcode Previewで実データ相当（園児＋保護者・保護者IDから入るケース）を確認可能

## レビュー観点
- [x] Containerの責務範囲（返却実行まで持つ／遷移は委譲）の切り方
- [x] 期限表示「6月20日(土)」（年なし）でよいか
- [ ] 1人1枠前提（複数冊設定時は未決事項として拡張）の扱い

🤖 Generated with [Claude Code](https://claude.com/claude-code)