### PR TITLE
fix: 設定⚙ボタンを右上に移動

### DIFF
--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Borrow/BorrowListContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Borrow/BorrowListContainerView.swift
@@ -103,7 +103,7 @@ struct BorrowListContainerView: View {
                 .searchable(text: $searchText, prompt: "図書のタイトルまたは著者で検索")
             #endif
             .toolbar {
-                ToolbarItem(placement: .topBarLeading) {
+                ToolbarItem(placement: .topBarTrailing) {
                     Button("設定", systemImage: "gearshape") {
                         isSettingsPresented = true
                     }

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Return/ReturnListContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Return/ReturnListContainerView.swift
@@ -50,7 +50,7 @@ struct ReturnListContainerView: View {
                 familyScreen(for: userId)
             }
             .toolbar {
-                ToolbarItem(placement: .topBarLeading) {
+                ToolbarItem(placement: .topBarTrailing) {
                     Button("設定", systemImage: "gearshape") {
                         isSettingsPresented = true
                     }


### PR DESCRIPTION
検索まわりの操作が画面左に集まるため、管理入口の⚙は反対側（右上）の方が誤タップを防げる（オーナー指摘）。返却・貸出両タブに適用。

🤖 Generated with [Claude Code](https://claude.com/claude-code)