### PR TITLE
feat: 主動線のタイポグラフィを底上げ（段取り5）

### DIFF
--- a/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/Book/BookListView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/Book/BookListView.swift
@@ -53,6 +53,9 @@ public struct BookSection: Identifiable, Hashable {
 /// 画面制御はContainer Viewに委譲します。
 /// 五十音フィルターとセクション表示に対応
 public struct BookListView<RowAction: View>: View {
+    /// 空状態アイコンのサイズ（Dynamic Typeに追従してスケール）
+    @ScaledMetric(relativeTo: .largeTitle) private var emptyIconSize: CGFloat = 48
+    
     /// 五十音グループでセクション化された絵本
     public let sections: [BookSection]
     /// 検索テキスト
@@ -178,15 +181,15 @@ public struct BookListView<RowAction: View>: View {
     private var emptyStateView: some View {
         VStack(spacing: 16) {
             Image(systemName: "book.closed")
-                .font(.system(size: 48))
+                .font(.system(size: emptyIconSize))
                 .foregroundStyle(.secondary)
             
             Text("図書が登録されていません")
-                .font(.headline)
+                .font(.title3)
                 .foregroundStyle(.secondary)
             
             Text("設定画面から図書を登録してください")
-                .font(.caption)
+                .font(.subheadline)
                 .foregroundStyle(.tertiary)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -265,7 +268,7 @@ public struct BookRowView<RowAction: View>: View {
             
             VStack(alignment: .leading, spacing: 4) {
                 Text(book.title)
-                    .font(.headline)
+                    .font(.title3)
                 
                 Text(book.author ?? "")
                     .font(.subheadline)

--- a/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/Loan/RowActionButton.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/Loan/RowActionButton.swift
@@ -28,17 +28,22 @@ public struct RowActionButton: View {
         self.onTap = onTap
     }
     
+    private enum Layout {
+        /// 片手親指で押せるタップ領域の最小高さ（DESIGN_PRINCIPLES.md §5準拠）
+        static let minTapTargetHeight: CGFloat = 44
+    }
+    
     public var body: some View {
         Button(action: onTap) {
             HStack(spacing: 6) {
                 Image(systemName: systemImage)
-                    .font(.callout)
+                    .font(.body)
                 Text(title)
-                    .font(.callout)
+                    .font(.body)
             }
             .foregroundStyle(.white)
             .padding(.horizontal, 16)
-            .padding(.vertical, 8)
+            .frame(minHeight: Layout.minTapTargetHeight)
             .background(tint)
             .cornerRadius(8)
         }

--- a/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/Views/SuccessFeedbackView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/Views/SuccessFeedbackView.swift
@@ -41,10 +41,12 @@ public struct SuccessFeedback: Equatable, Sendable {
 /// チェックマークとメッセージを表示します。
 /// 操作を妨げないよう、タップは透過します。
 public struct SuccessFeedbackView: View {
+    /// チェックアイコンのサイズ（Dynamic Typeに追従してスケール）
+    @ScaledMetric(relativeTo: .largeTitle) private var iconSize: CGFloat = 64
+    
     let message: String
     
     private enum Layout {
-        static let iconSize: CGFloat = 64
         static let spacing: CGFloat = 12
         static let padding: CGFloat = 32
         static let cornerRadius: CGFloat = 20
@@ -57,11 +59,11 @@ public struct SuccessFeedbackView: View {
     public var body: some View {
         VStack(spacing: Layout.spacing) {
             Image(systemName: "checkmark.circle.fill")
-                .font(.system(size: Layout.iconSize))
+                .font(.system(size: iconSize))
                 .foregroundStyle(.green)
             
             Text(message)
-                .font(.headline)
+                .font(.title3.bold())
                 .multilineTextAlignment(.center)
         }
         .padding(Layout.padding)


### PR DESCRIPTION
## 概要
Phase 2 段取り5。DESIGN_PRINCIPLES §5（1m離れて読める）を主動線に適用。**レビュー待ち。**

| 箇所 | 前 | 後 |
|---|---|---|
| 図書一覧のタイトル | .headline | **.title3** |
| 借りる/貸出中ボタン | .callout | **.body**＋タップ領域44pt |
| ✓カードの文言 | .headline | **.title3太字** |
| 空状態の文言 | .headline/.caption | .title3/.subheadline |
| 固定ptアイコン（✓64pt・空状態48pt） | 固定 | **@ScaledMetric**（Dynamic Type追従） |

名前一覧・家庭の枠・Undoカードは既に基準適合のため変更なし。管理系（設定内）は方針どおり標準サイズ据え置き。

実装: Sonnet／仕様・監査: Fable 5。xcodebuild test 全59件成功。

🤖 Generated with [Claude Code](https://claude.com/claude-code)