### PR TITLE
feat: 図書検索に検索候補（サジェスト）を表示する

### DIFF
--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/States/BookSectionsState.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/States/BookSectionsState.swift
@@ -16,8 +16,17 @@ class BookSectionsState {
     /// /// 五十音順グループごとの絵本分類
     private var bookSections: [BookSection] = []
     
+    private enum Suggestion {
+        static let maxCount = 8
+    }
+    
     init(books: [Book]) {
         self.bookSections = createSections(from: books)
+    }
+    
+    /// 全絵本（セクションから都度導出。bookSectionsとの二重保持を避ける）
+    private var allBooks: [Book] {
+        bookSections.flatMap { $0.books }
     }
     
     /// フィルタリング・ソート済みの絵本セクション
@@ -33,6 +42,37 @@ class BookSectionsState {
         
         // 2. ソート
         return sorted(sections: filteredSections, by: sortType)
+    }
+    
+    /// 検索テキスト（＋現在のかなフィルタ）に対する図書タイトルの候補
+    ///
+    /// 一覧側と同じ順序（テキスト検索→かなフィルタ）で絞り込んでからスコアリングすることで、
+    /// かなフィルタが有効な状態でも候補タップ後に一覧が空にならないようにする。
+    /// スコア降順・タイトル重複除去・上位`limit`件のみ返す。
+    public func suggestions(
+        for searchText: String, kanaFilter: KanaGroup?, limit: Int = Suggestion.maxCount
+    ) -> [Book] {
+        let trimmed = searchText.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return [] }
+        
+        let candidates: [Book] =
+            if let kanaFilter {
+                allBooks.filter { ($0.kanaGroup ?? .other) == kanaFilter }
+            } else {
+                allBooks
+            }
+
+        let scored = BookSearchScorer().scoreSearchResults(
+            searchQuery: BookSearchQuery(title: trimmed),
+            books: candidates)
+        
+        var seenTitles = Set<String>()
+        return
+            scored
+            .filter { $0.score > 0 }
+            .compactMap { seenTitles.insert($0.book.title).inserted ? $0.book : nil }
+            .prefix(limit)
+            .map { $0 }
     }
     
     /// 全絵本からBookSectionの配列を作成

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/SettingsBookListContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/SettingsBookListContainerView.swift
@@ -12,6 +12,8 @@ struct SettingsBookListContainerView: View {
     @Environment(LoanModel.self) private var loanModel
     
     @State private var searchText = ""
+    /// サジェスト候補算出用にデバウンスした検索テキスト（一覧の絞り込み自体は即時のsearchTextを使う）
+    @State private var debouncedSearchText = ""
     @State private var isAddSheetPresented = false
     @State private var editingBook: Book?
     @State private var isEditMode = false
@@ -38,6 +40,20 @@ struct SettingsBookListContainerView: View {
             BookStatusView(isCurrentlyLent: loanModel.isBookLent(bookId: book.id))
         }
         .navigationTitle("図書管理")
+        .bookSearchable(
+            text: $searchText,
+            suggestions: bookSectionsState.suggestions(
+                for: debouncedSearchText, kanaFilter: selectedKanaFilter)
+        )
+        .task(id: searchText) {
+            do {
+                try await Task.sleep(for: .milliseconds(300))
+                debouncedSearchText = searchText
+            } catch {
+                // キャンセル（新しい入力があった）ので何もしない
+                return
+            }
+        }
         .navigationDestination(for: Book.self) { book in
             BookDetailContainerView(book: book)
         }

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/View+BookSearchable.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/View+BookSearchable.swift
@@ -1,0 +1,42 @@
+import PictureBookLendingDomain
+import SwiftUI
+
+/// 図書検索用の`.searchable` + `.searchSuggestions`をまとめて適用するView拡張
+///
+/// 貸出タブ・設定の図書一覧で検索バーとサジェスト表示を共通化する。
+/// 候補をタップするとタイトルが検索欄に入り、一覧が絞り込まれる（`.searchCompletion`）。
+extension View {
+    func bookSearchable(text: Binding<String>, suggestions: [Book]) -> some View {
+        #if os(iOS)
+            self.searchable(
+                text: text,
+                placement: .navigationBarDrawer(displayMode: .always),
+                prompt: "図書のタイトルまたは著者で検索"
+            )
+            .searchSuggestions {
+                bookSuggestionRows(suggestions)
+            }
+        #else
+            self.searchable(text: text, prompt: "図書のタイトルまたは著者で検索")
+                .searchSuggestions {
+                    bookSuggestionRows(suggestions)
+                }
+        #endif
+    }
+}
+
+/// 検索候補の行表示（タイトル＋著者）
+@ViewBuilder
+private func bookSuggestionRows(_ suggestions: [Book]) -> some View {
+    ForEach(suggestions) { book in
+        VStack(alignment: .leading, spacing: 2) {
+            Text(book.title)
+            if let author = book.author {
+                Text(author)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .searchCompletion(book.title)
+    }
+}

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Borrow/BorrowListContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Borrow/BorrowListContainerView.swift
@@ -33,6 +33,8 @@ struct BorrowListContainerView: View {
     /// 利用者選択画面で組チップにより絞り込み中の組ID（nilなら全組）
     @State private var selectedClassGroupId: UUID?
     @State private var searchText = ""
+    /// サジェスト候補算出用にデバウンスした検索テキスト（一覧の絞り込み自体は即時のsearchTextを使う）
+    @State private var debouncedSearchText = ""
     @State private var selectedKanaFilter: KanaGroup?
     @State private var selectedSortType: BookSortType = .title
     /// 五十音グループでセクション化された全図書データ（フィルタリング・ソート前のベース）
@@ -94,14 +96,20 @@ struct BorrowListContainerView: View {
                 }
             }
             .navigationTitle("貸出")
-            #if os(iOS)
-                .searchable(
-                    text: $searchText,
-                    placement: .navigationBarDrawer(displayMode: .always),
-                    prompt: "図書のタイトルまたは著者で検索")
-            #else
-                .searchable(text: $searchText, prompt: "図書のタイトルまたは著者で検索")
-            #endif
+            .bookSearchable(
+                text: $searchText,
+                suggestions: bookSectionsState.suggestions(
+                    for: debouncedSearchText, kanaFilter: selectedKanaFilter)
+            )
+            .task(id: searchText) {
+                do {
+                    try await Task.sleep(for: .milliseconds(300))
+                    debouncedSearchText = searchText
+                } catch {
+                    // キャンセル（新しい入力があった）ので何もしない
+                    return
+                }
+            }
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {
                     Button("設定", systemImage: "gearshape") {

--- a/PictureBookLendingAdminApp/PictureBookLendingAdminTests/BookSectionTests.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdminTests/BookSectionTests.swift
@@ -420,6 +420,123 @@ struct BookSectionTests {
         #expect(books[4].managementNumber == "あ１０")  // あ10
     }
     
+    // MARK: - suggestions Tests
+    
+    /// 空文字での候補取得テスト
+    ///
+    /// 検索テキストが空の場合は候補が空配列になることを確認します。
+    @Test("空文字での候補取得")
+    func suggestionsEmptyText() {
+        // 1. Arrange - 準備
+        let bookSectionsState = BookSectionsState(books: testBooks)
+        
+        // 2. Act - 実行
+        let suggestions = bookSectionsState.suggestions(for: "", kanaFilter: nil)
+        
+        // 3. Assert - 検証
+        #expect(suggestions.isEmpty)
+    }
+    
+    /// 前方一致が部分一致より上位に来ることを確認するテスト
+    @Test("前方一致が部分一致より上位")
+    func suggestionsPrefixMatchRanksHigher() {
+        // 1. Arrange - 準備（"は"で始まる本と、"は"を含むが先頭ではない本）
+        let books = [
+            Book(title: "こわいはなし", kanaGroup: .ka),
+            Book(title: "はらぺこあおむし", kanaGroup: .ha),
+        ]
+        let bookSectionsState = BookSectionsState(books: books)
+        
+        // 2. Act - 実行
+        let suggestions = bookSectionsState.suggestions(for: "は", kanaFilter: nil)
+        
+        // 3. Assert - 検証
+        #expect(suggestions.first?.title == "はらぺこあおむし")
+    }
+    
+    /// タイプミスでも候補に入ることを確認するテスト
+    @Test("タイプミスでも候補に入る")
+    func suggestionsToleratesTypo() {
+        // 1. Arrange - 準備
+        let bookSectionsState = BookSectionsState(books: testBooks)
+        
+        // 2. Act - 実行（「あおむし」を「あおむち」と誤入力）
+        let suggestions = bookSectionsState.suggestions(for: "はらぺこあおむち", kanaFilter: nil)
+        
+        // 3. Assert - 検証
+        #expect(suggestions.contains { $0.title == "はらぺこあおむし" })
+    }
+    
+    /// limit で件数が上限に収まることを確認するテスト
+    @Test("limitで件数が上限に収まる")
+    func suggestionsRespectsLimit() {
+        // 1. Arrange - 準備（10冊、すべて"ほん"を含むタイトル）
+        let manyBooks = (0..<10).map { Book(title: "ほん\($0)", kanaGroup: .ha) }
+        let bookSectionsState = BookSectionsState(books: manyBooks)
+        
+        // 2. Act - 実行
+        let suggestions = bookSectionsState.suggestions(for: "ほん", kanaFilter: nil, limit: 3)
+        
+        // 3. Assert - 検証
+        #expect(suggestions.count == 3)
+    }
+    
+    /// ヒットなしの場合は空配列になることを確認するテスト
+    @Test("ヒットなしで空配列")
+    func suggestionsNoMatch() {
+        // 1. Arrange - 準備
+        let bookSectionsState = BookSectionsState(books: testBooks)
+        
+        // 2. Act - 実行
+        let suggestions = bookSectionsState.suggestions(for: "存在しない本のタイトル", kanaFilter: nil)
+        
+        // 3. Assert - 検証
+        #expect(suggestions.isEmpty)
+    }
+    
+    /// 同一タイトルの重複除去テスト
+    @Test("同一タイトルは重複除去される")
+    func suggestionsDedupesSameTitle() {
+        // 1. Arrange - 準備（同じタイトルの本が2冊）
+        let books = [
+            Book(title: "はらぺこあおむし", managementNumber: "は001", kanaGroup: .ha),
+            Book(title: "はらぺこあおむし", managementNumber: "は002", kanaGroup: .ha),
+        ]
+        let bookSectionsState = BookSectionsState(books: books)
+        
+        // 2. Act - 実行
+        let suggestions = bookSectionsState.suggestions(for: "はらぺこ", kanaFilter: nil)
+        
+        // 3. Assert - 検証
+        #expect(suggestions.count == 1)
+    }
+    
+    /// かなフィルタが選択されている場合、そのグループ外のタイトルは候補に出ないことを確認するテスト
+    @Test("かなフィルタ選択中はグループ外のタイトルが候補に出ない")
+    func suggestionsRespectsKanaFilter() {
+        // 1. Arrange - 準備
+        let bookSectionsState = BookSectionsState(books: testBooks)
+        
+        // 2. Act - 実行（"は行"フィルタ中に、か行の本のタイトルで検索）
+        let suggestions = bookSectionsState.suggestions(for: "かきくけこ", kanaFilter: .ha)
+        
+        // 3. Assert - 検証（か行フィルタ外なので候補は出ない）
+        #expect(suggestions.isEmpty)
+    }
+    
+    /// かなフィルタと一致するタイトルは候補に出ることを確認するテスト
+    @Test("かなフィルタと一致するタイトルは候補に出る")
+    func suggestionsMatchesWithinKanaFilter() {
+        // 1. Arrange - 準備
+        let bookSectionsState = BookSectionsState(books: testBooks)
+        
+        // 2. Act - 実行（"は行"フィルタ中に、は行の本のタイトルで検索）
+        let suggestions = bookSectionsState.suggestions(for: "あおむし", kanaFilter: .ha)
+        
+        // 3. Assert - 検証
+        #expect(suggestions.contains { $0.title == "はらぺこあおむし" })
+    }
+    
     // MARK: - Integration Tests
     
     /// 全機能統合テスト

--- a/docs/TERMS.md
+++ b/docs/TERMS.md
@@ -15,3 +15,4 @@
 | 返却日 | returnedDate | 実際返却日, 返却完了日, actualReturnDate | 図書が実際に返却された日付（未返却時はnil） |
 | 返却済み | isReturned | 返却フラグ, 完了ステータス, returned, completed | 図書が返却済みかどうかの論理値（計算プロパティ） |
 | 貸出期間 | loanPeriod | 貸出日数, 借用期間, lendingDuration, borrowingPeriod | 図書を貸し出してから返却期限までの日数（例：14日間） |
+| 検索候補 | suggestion | サジェスト（UI文言として）, オートコンプリート | 検索入力中に表示する登録済み図書タイトルの候補。タップすると検索欄に反映され一覧が絞り込まれる |


### PR DESCRIPTION
## Summary
- 貸出タブ・設定＞図書管理の検索欄に、入力中の図書タイトル候補をリアルタイム表示（`.searchable` + `.searchSuggestions`）。候補タップで検索欄が埋まり一覧が絞り込まれる
- 候補ランキングは既存の`BookSearchScorer`を再利用し、前方一致・部分一致・タイプミス（Levenshtein類似度）を許容
- かなフィルタが選択中の場合は候補もそのグループ内に限定し、タップ後に一覧が空にならないようにした
- 設定＞図書管理はこれまで`searchText`を配線済みだが`.searchable`が無く検索バー自体が未搭載だったため、あわせて有効化
- `docs/TERMS.md`に「検索候補」を追加

Closes #180

## Test plan
- [x] `BookSectionsState.suggestions(for:kanaFilter:limit:)`の単体テストを追加（空文字/前方一致優先/タイプミス許容/limit/ヒット無し/タイトル重複除去/かなフィルタ整合）
- [x] `xcodebuild test`で全93テスト成功（iOS Simulator, iPad mini destination）
- [x] `swift format lint`クリーン
- [x] SwiftUI Previewで貸出タブ・設定＞図書管理のレイアウト崩れ無しを確認
- [x] 実機（Akane's iPad）にインストールし起動確認（クラッシュ無し）
- [ ] オーナーによる実機での検索候補タップ操作の最終確認（CLAUDE.mdの方針によりUX変更は実機確認＋レビュー後にマージ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
