### PR TITLE
refactor: FamilyLoanSlotsContainerViewのalertStateを自前の@Stateにする

### DIFF
--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/States/BookSections.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/States/BookSections.swift
@@ -1,23 +1,16 @@
-//
-//  BookSectionState+sorted.swift
-//  PictureBookLendingAdmin
-//
-//  Created by takuya_tominaga on 8/29/25.
-//
-
-import Observation
 import PictureBookLendingDomain
 import PictureBookLendingUI
-import SwiftUI
 
-/// グループ単位のBookオブジェクトを管理するState
-@Observable
-class BookSectionsState {
-    /// /// 五十音順グループごとの絵本分類
-    private var bookSections: [BookSection] = []
+/// 五十音グループ単位でセクション化した絵本の集まり（フィルタリング・ソート前のベース）
+///
+/// 初期化時に分類するだけで内部状態は変化しないため、値型として保持し、
+/// 呼び出し側は`bookModel.books`から都度導出する（手動同期を不要にする）。
+struct BookSections {
+    /// 五十音順グループごとの絵本分類
+    private let bookSections: [BookSection]
     
     init(books: [Book]) {
-        self.bookSections = createSections(from: books)
+        self.bookSections = Self.createSections(from: books)
     }
     
     /// 全絵本（セクションから都度導出。bookSectionsとの二重保持を避ける）
@@ -30,11 +23,11 @@ class BookSectionsState {
     /// 部分一致（＋かなフィルタ）で0件のときは、タイプミスを許容した
     /// あいまい検索（Levenshtein類似度）で図書を救済するフォールバックを行う。
     /// かなフィルタ選択中は、フォールバックもそのグループ内に限定する。
-    public func filter(
+    func filter(
         searchText: String, kanafilter: KanaGroup?, sortType: BookSortType
     ) -> [BookSection] {
         // 1. フィルタリング（部分一致＋かなフィルタ）
-        var filteredSections = filtered(
+        var filteredSections = Self.filtered(
             sections: bookSections,
             searchText: searchText,
             selectedKanaFilter: kanafilter
@@ -47,7 +40,7 @@ class BookSectionsState {
         }
         
         // 3. ソート
-        return sorted(sections: filteredSections, by: sortType)
+        return Self.sorted(sections: filteredSections, by: sortType)
     }
     
     /// 部分一致で0件のとき、タイプミスを許容したあいまい検索で図書を探すフォールバック
@@ -72,14 +65,14 @@ class BookSectionsState {
             .filter { $0.score > 0 }
             .map { $0.book }
         
-        return createSections(from: matchedBooks)
+        return Self.createSections(from: matchedBooks)
     }
     
     /// 全絵本からBookSectionの配列を作成
-    private func createSections(from books: [Book]) -> [BookSection] {
+    private static func createSections(from books: [Book]) -> [BookSection] {
         // 五十音グループごとに分類
         let groupedBooks = Dictionary(grouping: books) { book -> KanaGroup in
-            return book.kanaGroup ?? .other
+            book.kanaGroup ?? .other
         }
         
         // セクションを作成
@@ -92,7 +85,7 @@ class BookSectionsState {
     }
     
     /// 検索テキストとかなフィルターでセクション配列をフィルタリング
-    private func filtered(
+    private static func filtered(
         sections: [BookSection],
         searchText: String,
         selectedKanaFilter: KanaGroup?
@@ -112,7 +105,7 @@ class BookSectionsState {
         }
         
         // 選択されたフィルターがある場合は該当セクションのみ表示
-        if let selectedKanaFilter = selectedKanaFilter {
+        if let selectedKanaFilter {
             filteredSections = filteredSections.filter { $0.kanaGroup == selectedKanaFilter }
         }
         
@@ -120,8 +113,9 @@ class BookSectionsState {
     }
     
     /// ソート方法に基づいてセクション配列をソート
-    private func sorted(sections: [BookSection], by sortType: BookSortType) -> [BookSection] {
-        return sections.map { section in
+    private static func sorted(sections: [BookSection], by sortType: BookSortType) -> [BookSection]
+    {
+        sections.map { section in
             let sortedBooks: [Book]
             switch sortType {
             case .title:

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/SettingsBookListContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/SettingsBookListContainerView.swift
@@ -21,12 +21,10 @@ struct SettingsBookListContainerView: View {
     /// 管理業務では著者・管理番号・貸出状況の情報密度が必要なためリストを既定にする
     /// （貸出タブは実物の表紙との照合が主タスクなのでグリッド既定。使い分けの経緯はissue #179）
     @State private var displayMode: BookDisplayMode = .list
-    /// 五十音グループでセクション化された全絵本データ（フィルタリング・ソート前のベース）
-    @State private var bookSectionsState: BookSectionsState = .init(books: [])
     
     var body: some View {
         BookListView(
-            sections: bookSectionsState.filter(
+            sections: bookSections.filter(
                 searchText: filterState.searchText,
                 kanafilter: filterState.selectedKanaFilter,
                 sortType: selectedSortType),
@@ -92,22 +90,24 @@ struct SettingsBookListContainerView: View {
         } message: {
             Text(alertState.message)
         }
-        .onChange(of: bookModel.books) {
-            loadBookSections()
-        }
         .onAppear {
             bookModel.refreshBooks()
             loanModel.refreshLoans()
-            loadBookSections()
         }
         .refreshable {
             bookModel.refreshBooks()
             loanModel.refreshLoans()
-            loadBookSections()
         }
     }
     
     // MARK: - Computed Properties
+    
+    /// 五十音グループでセクション化された全絵本データ（フィルタリング・ソート前のベース）
+    ///
+    /// `bookModel.books`から都度導出する。値型なので手動同期（onChange/onAppear）は不要。
+    private var bookSections: BookSections {
+        BookSections(books: bookModel.books)
+    }
     
     /// 検索テキストのバインディング（書き込みはStateの排他制御メソッドを経由させる）
     private var searchTextBinding: Binding<String> {
@@ -126,11 +126,6 @@ struct SettingsBookListContainerView: View {
     }
     
     // MARK: - Actions
-    
-    /// 絵本データから基本セクションを作成・更新
-    private func loadBookSections() {
-        bookSectionsState = BookSectionsState(books: bookModel.books)
-    }
     
     private func handleEditBook(_ book: Book) {
         editingBook = book

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Borrow/BorrowListContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Borrow/BorrowListContainerView.swift
@@ -242,7 +242,6 @@ struct BorrowListContainerView: View {
                     }
                     
                     FamilyLoanSlotsContainerView(
-                        alertState: $alertState,
                         undoFeedback: $undoFeedback,
                         userId: route.userId,
                         context: .borrowing(onSlotSelected: { slotUserId in

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Borrow/BorrowListContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Borrow/BorrowListContainerView.swift
@@ -39,8 +39,6 @@ struct BorrowListContainerView: View {
     @State private var scrollToTopTrigger = 0
     @State private var selectedSortType: BookSortType = .title
     @State private var displayMode: BookDisplayMode = .grid
-    /// 五十音グループでセクション化された全図書データ（フィルタリング・ソート前のベース）
-    @State private var bookSectionsState: BookSectionsState = .init(books: [])
     @State private var alertState = AlertState()
     @State private var successFeedback = SuccessFeedback()
     /// 貸出後、✓カードの表示が終わったらシートを閉じる（図書一覧へ戻す）ための予約フラグ
@@ -69,7 +67,7 @@ struct BorrowListContainerView: View {
     var body: some View {
         NavigationStack {
             BookListView(
-                sections: bookSectionsState.filter(
+                sections: bookSections.filter(
                     searchText: filterState.searchText,
                     kanafilter: filterState.selectedKanaFilter,
                     sortType: selectedSortType),
@@ -126,16 +124,11 @@ struct BorrowListContainerView: View {
                 }
             #endif
         }
-        .onChange(of: bookModel.books) {
-            loadBookSections()
-        }
         .onAppear {
             refreshData()
-            loadBookSections()
         }
         .refreshable {
             refreshData()
-            loadBookSections()
         }
         .sheet(item: $borrowSheetContext) { context in
             // 貸出中の案内だけの本は小さなフォームシートで十分（すぐ閉じられる）。
@@ -296,6 +289,13 @@ struct BorrowListContainerView: View {
     
     // MARK: - Computed Properties
     
+    /// 五十音グループでセクション化された全図書データ（フィルタリング・ソート前のベース）
+    ///
+    /// `bookModel.books`から都度導出する。値型なので手動同期（onChange/onAppear）は不要。
+    private var bookSections: BookSections {
+        BookSections(books: bookModel.books)
+    }
+    
     /// 検索テキストのバインディング（書き込みはStateの排他制御メソッドを経由させる）
     private var searchTextBinding: Binding<String> {
         Binding(
@@ -415,11 +415,6 @@ struct BorrowListContainerView: View {
         loanModel.refreshLoans()
         userModel.refreshUsers()
         classGroupModel.refreshClassGroups()
-    }
-    
-    /// 図書データから基本セクションを作成・更新
-    private func loadBookSections() {
-        bookSectionsState = BookSectionsState(books: bookModel.books)
     }
 }
 

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Family/FamilyLoanSlotsContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Family/FamilyLoanSlotsContainerView.swift
@@ -24,14 +24,19 @@ struct FamilyLoanSlotsContainerView: View {
     @Environment(LoanModel.self) private var loanModel
     @Environment(BookModel.self) private var bookModel
     
-    /// アラート状態管理（エラー表示用）
-    @Binding var alertState: AlertState
     /// 返却のUndoフィードバック状態管理
     ///
     /// 文脈enumに含めない：返却タブの返却Undoだけでなく、貸出フロー内の
     /// 「枠の入れ替え（先に返し忘れた本をその場で返却して空けるUndo）」でも
-    /// 使われる、両モード共通の状態のため（`handleReturn`参照）
+    /// 使われる、両モード共通の状態のため（`handleReturn`参照）。
+    /// alertStateと違い@Binding：返却完了で子ごとpopされた後もUndoカードは
+    /// 親レベルで生き残る必要があり、子より長寿命の状態は親所有が正しいため
     @Binding var undoFeedback: UndoFeedback
+    
+    /// アラート状態管理（エラー表示用）
+    ///
+    /// エラーアラートは子の生存中にしか出ないため、子が自前で持ち自分で`.alert`を付ける
+    @State private var alertState = AlertState()
     
     /// 家庭を特定する利用者ID（園児・保護者どちらでも可）
     let userId: UUID
@@ -45,6 +50,11 @@ struct FamilyLoanSlotsContainerView: View {
             onReturn: handleReturn(_:),
             onBorrow: handleBorrow(_:)
         )
+        .alert(alertState.title, isPresented: $alertState.isPresented) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(alertState.message)
+        }
     }
     
     // MARK: - Computed Properties
@@ -126,7 +136,6 @@ struct FamilyLoanSlotsContainerView: View {
 }
 
 #Preview("返却文脈（実データ相当）") {
-    @Previewable @State var alertState = AlertState()
     @Previewable @State var undoFeedback = UndoFeedback()
     
     let mockFactory = MockRepositoryFactory()
@@ -150,7 +159,6 @@ struct FamilyLoanSlotsContainerView: View {
     
     return ScrollView {
         FamilyLoanSlotsContainerView(
-            alertState: $alertState,
             undoFeedback: $undoFeedback,
             userId: mother.id,  // 保護者のIDから入っても同じ家庭に解決される
             context: .returning(onReturnCompleted: { _ in })

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Return/ReturnListContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Return/ReturnListContainerView.swift
@@ -94,7 +94,6 @@ struct ReturnListContainerView: View {
     private func familyScreen(for userId: UUID) -> some View {
         ScrollView {
             FamilyLoanSlotsContainerView(
-                alertState: $alertState,
                 undoFeedback: $undoFeedback,
                 userId: userId,
                 context: .returning(onReturnCompleted: handleReturnCompleted(hasRemainingLoans:))

--- a/PictureBookLendingAdminApp/PictureBookLendingAdminTests/BookSectionTests.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdminTests/BookSectionTests.swift
@@ -5,13 +5,13 @@ import Testing
 
 @testable import PictureBookLendingAdmin
 
-/// BookSectionsStateテストケース
+/// BookSectionsテストケース
 ///
-/// BookSectionsStateで定義された以下の機能をテストします：
+/// BookSectionsで定義された以下の機能をテストします：
 /// - セクション作成機能（初期化）
 /// - フィルタリング機能（filter）
 /// - ソート機能（filter内でのソート）
-@Suite("BookSectionsState Tests")
+@Suite("BookSections Tests")
 struct BookSectionTests {
     
     // MARK: - Test Data
@@ -39,8 +39,8 @@ struct BookSectionTests {
         let books = testBooks
         
         // 2. Act - 実行
-        let bookSectionsState = BookSectionsState(books: books)
-        let sections = bookSectionsState.filter(searchText: "", kanafilter: nil, sortType: .title)
+        let bookSections = BookSections(books: books)
+        let sections = bookSections.filter(searchText: "", kanafilter: nil, sortType: .title)
         
         // 3. Assert - 検証
         #expect(sections.count == 4)  // あ、か、は、その他
@@ -73,8 +73,8 @@ struct BookSectionTests {
         let books: [Book] = []
         
         // 2. Act - 実行
-        let bookSectionsState = BookSectionsState(books: books)
-        let sections = bookSectionsState.filter(searchText: "", kanafilter: nil, sortType: .title)
+        let bookSections = BookSections(books: books)
+        let sections = bookSections.filter(searchText: "", kanafilter: nil, sortType: .title)
         
         // 3. Assert - 検証
         #expect(sections.count == 0)
@@ -88,10 +88,10 @@ struct BookSectionTests {
     @Test("検索テキストによるフィルタリング")
     func filteredBySearchText() {
         // 1. Arrange - 準備
-        let bookSectionsState = BookSectionsState(books: testBooks)
+        let bookSections = BookSections(books: testBooks)
         
         // 2. Act - 実行（"あおむし"で検索）
-        let filteredSections = bookSectionsState.filter(
+        let filteredSections = bookSections.filter(
             searchText: "あおむし",
             kanafilter: nil,
             sortType: .title
@@ -110,10 +110,10 @@ struct BookSectionTests {
     @Test("著者名による検索フィルタリング")
     func filteredByAuthor() {
         // 1. Arrange - 準備
-        let bookSectionsState = BookSectionsState(books: testBooks)
+        let bookSections = BookSections(books: testBooks)
         
         // 2. Act - 実行（"エリック・カール"で検索）
-        let filteredSections = bookSectionsState.filter(
+        let filteredSections = bookSections.filter(
             searchText: "エリック・カール",
             kanafilter: nil,
             sortType: .title
@@ -130,10 +130,10 @@ struct BookSectionTests {
     @Test("五十音グループによるフィルタリング")
     func filteredByKanaGroup() {
         // 1. Arrange - 準備
-        let bookSectionsState = BookSectionsState(books: testBooks)
+        let bookSections = BookSections(books: testBooks)
         
         // 2. Act - 実行（か行のみ）
-        let filteredSections = bookSectionsState.filter(
+        let filteredSections = bookSections.filter(
             searchText: "",
             kanafilter: .ka,
             sortType: .title
@@ -151,10 +151,10 @@ struct BookSectionTests {
     @Test("複合フィルタリング")
     func filteredBySearchTextAndKanaGroup() {
         // 1. Arrange - 準備
-        let bookSectionsState = BookSectionsState(books: testBooks)
+        let bookSections = BookSections(books: testBooks)
         
         // 2. Act - 実行（"か"で検索 + か行フィルター）
-        let filteredSections = bookSectionsState.filter(
+        let filteredSections = bookSections.filter(
             searchText: "か",
             kanafilter: .ka,
             sortType: .title
@@ -173,10 +173,10 @@ struct BookSectionTests {
     @Test("フィルタリング結果なし")
     func filteredNoResults() {
         // 1. Arrange - 準備
-        let bookSectionsState = BookSectionsState(books: testBooks)
+        let bookSections = BookSections(books: testBooks)
         
         // 2. Act - 実行（存在しない文字列で検索）
-        let filteredSections = bookSectionsState.filter(
+        let filteredSections = bookSections.filter(
             searchText: "存在しない本",
             kanafilter: nil,
             sortType: .title
@@ -194,10 +194,10 @@ struct BookSectionTests {
     @Test("タイトルソート")
     func sortedByTitle() {
         // 1. Arrange - 準備
-        let bookSectionsState = BookSectionsState(books: testBooks)
+        let bookSections = BookSections(books: testBooks)
         
         // 2. Act - 実行（か行とタイトルソート）
-        let sortedSections = bookSectionsState.filter(
+        let sortedSections = bookSections.filter(
             searchText: "",
             kanafilter: .ka,
             sortType: .title
@@ -216,10 +216,10 @@ struct BookSectionTests {
     @Test("管理番号ソート")
     func sortedByManagementNumber() {
         // 1. Arrange - 準備
-        let bookSectionsState = BookSectionsState(books: testBooks)
+        let bookSections = BookSections(books: testBooks)
         
         // 2. Act - 実行（あ行と管理番号ソート）
-        let sortedSections = bookSectionsState.filter(
+        let sortedSections = bookSections.filter(
             searchText: "",
             kanafilter: .a,
             sortType: .managementNumber
@@ -238,10 +238,10 @@ struct BookSectionTests {
     @Test("管理番号なしを含むソート")
     func sortedByManagementNumberWithNil() {
         // 1. Arrange - 準備
-        let bookSectionsState = BookSectionsState(books: testBooks)
+        let bookSections = BookSections(books: testBooks)
         
         // 2. Act - 実行（は行と管理番号ソート）
-        let sortedSections = bookSectionsState.filter(
+        let sortedSections = bookSections.filter(
             searchText: "",
             kanafilter: .ha,
             sortType: .managementNumber
@@ -267,10 +267,10 @@ struct BookSectionTests {
             Book(title: "本D", managementNumber: "か001", kanaGroup: .ka),
             Book(title: "本E", managementNumber: nil, kanaGroup: .ka),
         ]
-        let bookSectionsState = BookSectionsState(books: complexBooks)
+        let bookSections = BookSections(books: complexBooks)
         
         // 2. Act - 実行
-        let sortedSections = bookSectionsState.filter(
+        let sortedSections = bookSections.filter(
             searchText: "",
             kanafilter: nil,
             sortType: .managementNumber
@@ -300,10 +300,10 @@ struct BookSectionTests {
             Book(title: "本C", managementNumber: "あ001", kanaGroup: .a),  // 半角001
             Book(title: "本D", managementNumber: "あ１００", kanaGroup: .a),  // 全角100
         ]
-        let bookSectionsState = BookSectionsState(books: fullWidthBooks)
+        let bookSections = BookSections(books: fullWidthBooks)
         
         // 2. Act - 実行
-        let sortedSections = bookSectionsState.filter(
+        let sortedSections = bookSections.filter(
             searchText: "",
             kanafilter: nil,
             sortType: .managementNumber
@@ -332,10 +332,10 @@ struct BookSectionTests {
             Book(title: "本C", managementNumber: "あ０２０", kanaGroup: .sa),  // 全角020（あ）
             Book(title: "本D", managementNumber: "さ010", kanaGroup: .sa),  // 半角010
         ]
-        let bookSectionsState = BookSectionsState(books: mixedBooks)
+        let bookSections = BookSections(books: mixedBooks)
         
         // 2. Act - 実行
-        let sortedSections = bookSectionsState.filter(
+        let sortedSections = bookSections.filter(
             searchText: "",
             kanafilter: nil,
             sortType: .managementNumber
@@ -365,10 +365,10 @@ struct BookSectionTests {
             Book(title: "本D", managementNumber: "abc050xyz", kanaGroup: .other),
             Book(title: "本E", managementNumber: "book100", kanaGroup: .other),  // 末尾文字列なし
         ]
-        let bookSectionsState = BookSectionsState(books: patternBooks)
+        let bookSections = BookSections(books: patternBooks)
         
         // 2. Act - 実行
-        let sortedSections = bookSectionsState.filter(
+        let sortedSections = bookSections.filter(
             searchText: "",
             kanafilter: nil,
             sortType: .managementNumber
@@ -399,10 +399,10 @@ struct BookSectionTests {
             Book(title: "本D", managementNumber: "B003", kanaGroup: .other),  // 英字＋数字
             Book(title: "本E", managementNumber: "A010", kanaGroup: .other),  // 英字＋数字
         ]
-        let bookSectionsState = BookSectionsState(books: complexBooks)
+        let bookSections = BookSections(books: complexBooks)
         
         // 2. Act - 実行
-        let sortedSections = bookSectionsState.filter(
+        let sortedSections = bookSections.filter(
             searchText: "",
             kanafilter: nil,
             sortType: .managementNumber
@@ -428,10 +428,10 @@ struct BookSectionTests {
     @Test("タイプミスでフォールバックが効く")
     func fuzzyFallbackToleratesTypo() {
         // 1. Arrange - 準備
-        let bookSectionsState = BookSectionsState(books: testBooks)
+        let bookSections = BookSections(books: testBooks)
         
         // 2. Act - 実行（「あおむし」を「あおむち」と誤入力）
-        let sections = bookSectionsState.filter(
+        let sections = bookSections.filter(
             searchText: "はらぺこあおむち",
             kanafilter: nil,
             sortType: .title
@@ -447,10 +447,10 @@ struct BookSectionTests {
     @Test("部分一致でヒットがあればフォールバックしない")
     func fuzzyFallbackNotTriggeredWhenPartialMatchExists() {
         // 1. Arrange - 準備
-        let bookSectionsState = BookSectionsState(books: testBooks)
+        let bookSections = BookSections(books: testBooks)
         
         // 2. Act - 実行（"はらぺこ"は部分一致でヒットする）
-        let sections = bookSectionsState.filter(
+        let sections = bookSections.filter(
             searchText: "はらぺこ",
             kanafilter: nil,
             sortType: .title
@@ -465,10 +465,10 @@ struct BookSectionTests {
     @Test("全くヒットしない入力では空")
     func fuzzyFallbackNoMatchReturnsEmpty() {
         // 1. Arrange - 準備
-        let bookSectionsState = BookSectionsState(books: testBooks)
+        let bookSections = BookSections(books: testBooks)
         
         // 2. Act - 実行（完全に無関係な長い文字列で検索）
-        let sections = bookSectionsState.filter(
+        let sections = bookSections.filter(
             searchText: "存在しない本のタイトル",
             kanafilter: nil,
             sortType: .title
@@ -482,10 +482,10 @@ struct BookSectionTests {
     @Test("かなフィルタ選択中はフォールバックもグループ内のみ")
     func fuzzyFallbackRespectsKanaFilter() {
         // 1. Arrange - 準備
-        let bookSectionsState = BookSectionsState(books: testBooks)
+        let bookSections = BookSections(books: testBooks)
         
         // 2. Act - 実行（か行フィルタ中に、は行の本のタイトルをタイプミス込みで検索）
-        let sections = bookSectionsState.filter(
+        let sections = bookSections.filter(
             searchText: "はらぺこあおむち",
             kanafilter: .ka,
             sortType: .title
@@ -503,10 +503,10 @@ struct BookSectionTests {
     @Test("全機能統合テスト")
     func fullWorkflow() {
         // 1. Arrange - 準備
-        let bookSectionsState = BookSectionsState(books: testBooks)
+        let bookSections = BookSections(books: testBooks)
         
         // 2. Act - 実行（"か"で検索、か行フィルター、管理番号順ソート）
-        let sortedSections = bookSectionsState.filter(
+        let sortedSections = bookSections.filter(
             searchText: "か",
             kanafilter: .ka,
             sortType: .managementNumber


### PR DESCRIPTION
Closes #195

⛓️ **PRチェーン2段目**です。マージ順: #197 → 本PR → (#194 → #193 続く予定)。#197マージ後にbaseをmainへ変更してください（私に言ってもらえれば retarget します）。

## 概要

共有部品 `FamilyLoanSlotsContainerView` が親の `alertState` への`@Binding`を受け取っていたのをやめ、子が自分の`@State`＋`.alert`で持つ標準作法に変更します。エラーアラートは子の生存中にしか出ないため、共有自体が不要でした。

`undoFeedback` は**意図的に@Bindingのまま**です（返却完了で子がpopされた後もUndoカードは親レベルで生き残る必要があるため）。この所有判断の理由は両方ドキュメントコメントに明記しました。

## 変更内容

- `FamilyLoanSlotsContainerView`: `@Binding var alertState` → `@State private var alertState = AlertState()`、`body`に`.alert`追加、Preview更新
- `ReturnListContainerView` / `BorrowListContainerView`: 呼び出しから`alertState:`引数を削除（親側のalertStateは親自身のエラー用に使用中のため残置）

## テスト

- swift format lint: 違反0
- 全体ビルド: BUILD SUCCEEDED
- 全テスト（iPad Pro 13-inch (M5) シミュレータ）: 59 tests 全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)