### PR TITLE
refactor: RegisterModelをApp層へ移設しBookRegisterViewModelに改名（状態管理ルールをCLAUDE.mdに追記）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -231,6 +231,20 @@ struct BookListContainerView: View {
   * **重要**: State型はApp層（ContainerViewと同じモジュール）に定義する
 * **Model** : アプリ横断で共有するビジネスロジック状態 (`BooksModel`, `UsersModel`)
 
+### 状態の所有権ルール（Container間の状態共有）
+
+* 状態は寿命が一致するViewが所有する。画面と同じ寿命の状態は、その画面の@Stateで持つ
+* 通知系UI状態（AlertState / SuccessFeedback / UndoFeedback等）を子Containerへ@Bindingで渡さない。エラーは起きた場所（子）が自分の@State＋.alertで見せる
+* 例外: 状態が子Viewより長生きする必要がある場合（例: 子がpopされた後も残るUndoカード）のみ、親所有＋@Binding共有を許可し、理由をドキュメントコメントに残す
+* 子→親のイベント通知はクロージャ（onXX: (...) -> Void）で行う。クロージャを持つViewはEquatable準拠を検討
+
+### 状態を持つ型の命名・配置
+
+* アプリ全域の状態＋ビジネスロジック = 「〜Model」: Model層に置き、@Environmentで配布する
+* 1画面の状態＋画面ロジック = 「〜ViewModel」: App層のViewModels/に置き、画面のContainerViewが@Stateで生成する
+* ただの値（AlertState等の共通State型）= struct: App層（既存ルールどおり）
+* 既にある状態から計算できる値は@Stateにコピーせず、computed propertyで導出する（同期するな、導出せよ）
+
 ---
 
 ## 🎯 責任分離（Separation of Concerns）

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/ViewModels/BookRegisterViewModel.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/ViewModels/BookRegisterViewModel.swift
@@ -3,7 +3,7 @@ import Observation
 import PictureBookLendingDomain
 
 /// 絵本登録に関するエラー
-public enum RegisterModelError: Error, Equatable, LocalizedError {
+enum BookRegisterViewModelError: Error, Equatable, LocalizedError {
     /// 検索に失敗した場合のエラー
     case searchFailed
     /// 登録に失敗した場合のエラー
@@ -13,7 +13,7 @@ public enum RegisterModelError: Error, Equatable, LocalizedError {
     /// 不明なエラー
     case unknown
     
-    public var errorDescription: String? {
+    var errorDescription: String? {
         switch self {
         case .searchFailed:
             return "絵本の検索に失敗しました"
@@ -27,13 +27,13 @@ public enum RegisterModelError: Error, Equatable, LocalizedError {
     }
 }
 
-/// 絵本登録モデル
+/// 絵本登録画面のViewModel
 ///
 /// タイトル・著者入力による絵本検索と登録機能を提供します。
 /// 検索結果のスコアリング、手動入力との切り替え、登録状態管理を担当します。
 @Observable
 @MainActor
-public class RegisterModel {
+class BookRegisterViewModel {
     
     // MARK: - Dependencies
     
@@ -45,53 +45,41 @@ public class RegisterModel {
     // MARK: - Observable Properties
     
     /// 検索入力状態
-    public var searchTitle: String = ""
-    public var searchAuthor: String = ""
+    var searchTitle: String = ""
+    var searchAuthor: String = ""
     
     /// 検索結果
-    public var searchResults: [ScoredBook] = []
-    public var isSearching: Bool = false
-    public var searchError: String?
+    var searchResults: [ScoredBook] = []
+    var isSearching: Bool = false
+    var searchError: String?
     
     /// 選択された検索結果
-    public var selectedResult: ScoredBook?
+    var selectedResult: ScoredBook?
     
     /// 手動入力モードの状態
-    public var isManualEntryMode: Bool = false
-    public var manualBook: Book?
+    var isManualEntryMode: Bool = false
+    var manualBook: Book?
     
     /// 登録状態
-    public var isRegistering: Bool = false
-    public var registrationError: String?
+    var isRegistering: Bool = false
+    var registrationError: String?
     
     // MARK: - Computed Properties
     
     /// 検索実行可能かどうか
-    public var canSearch: Bool {
+    var canSearch: Bool {
         let hasTitleInput = !searchTitle.trimmingCharacters(in: .whitespaces).isEmpty
         let hasAuthorInput = !searchAuthor.trimmingCharacters(in: .whitespaces).isEmpty
-        let result = (hasTitleInput || hasAuthorInput) && !isSearching
-        
-        #if DEBUG
-            print("🔍 canSearch check:")
-            print("  - searchTitle: '\(searchTitle)'")
-            print("  - searchAuthor: '\(searchAuthor)'")
-            print("  - hasTitleInput: \(hasTitleInput)")
-            print("  - hasAuthorInput: \(hasAuthorInput)")
-            print("  - isSearching: \(isSearching)")
-            print("  - result: \(result)")
-        #endif
-        
-        return result
+        return (hasTitleInput || hasAuthorInput) && !isSearching
     }
     
     /// 登録実行可能かどうか
-    public var canRegister: Bool {
+    var canRegister: Bool {
         !isRegistering && (selectedResult != nil || manualBook != nil)
     }
     
     /// 現在の登録対象の絵本
-    public var bookToRegister: Book? {
+    var bookToRegister: Book? {
         if isManualEntryMode {
             return manualBook
         } else {
@@ -101,7 +89,7 @@ public class RegisterModel {
     
     // MARK: - Initialization
     
-    public init(
+    init(
         gateway: BookSearchGatewayProtocol,
         scorer: BookSearchScorer = BookSearchScorer(),
         normalizer: StringNormalizer,
@@ -116,7 +104,7 @@ public class RegisterModel {
     // MARK: - Search Actions
     
     /// タイトル・著者検索を実行
-    public func searchBooks() throws {
+    func searchBooks() throws {
         guard canSearch else { return }
         
         isSearching = true
@@ -160,14 +148,14 @@ public class RegisterModel {
     }
     
     /// 検索結果をクリア
-    public func clearSearchResults() {
+    func clearSearchResults() {
         searchResults = []
         selectedResult = nil
         searchError = nil
     }
     
     /// 検索結果を選択
-    public func selectSearchResult(_ result: ScoredBook) {
+    func selectSearchResult(_ result: ScoredBook) {
         selectedResult = result
         isManualEntryMode = false
     }
@@ -175,7 +163,7 @@ public class RegisterModel {
     // MARK: - Manual Entry Actions
     
     /// 手動入力モードに切り替え
-    public func switchToManualEntry() {
+    func switchToManualEntry() {
         isManualEntryMode = true
         selectedResult = nil
         
@@ -199,22 +187,22 @@ public class RegisterModel {
     }
     
     /// 検索結果モードに切り替え
-    public func switchToSearchResults() {
+    func switchToSearchResults() {
         isManualEntryMode = false
         manualBook = nil
     }
     
     /// 手動入力の絵本情報を更新
-    public func updateManualBook(_ book: Book) {
+    func updateManualBook(_ book: Book) {
         manualBook = book
     }
     
     // MARK: - Registration Actions
     
     /// 絵本を登録
-    public func registerBook() throws -> Book {
+    func registerBook() throws -> Book {
         guard canRegister, let book = bookToRegister else {
-            throw RegisterModelError.registrationFailed
+            throw BookRegisterViewModelError.registrationFailed
         }
         
         isRegistering = true
@@ -232,14 +220,14 @@ public class RegisterModel {
         } catch {
             isRegistering = false
             registrationError = handleRegistrationError(error)
-            throw RegisterModelError.registrationFailed
+            throw BookRegisterViewModelError.registrationFailed
         }
     }
     
     // MARK: - State Management
     
     /// 登録状態をリセット
-    public func resetRegistrationState() {
+    func resetRegistrationState() {
         searchTitle = ""
         searchAuthor = ""
         searchResults = []
@@ -251,7 +239,7 @@ public class RegisterModel {
     }
     
     /// 検索分析を取得
-    public func getSearchAnalysis() -> SearchAnalysis? {
+    func getSearchAnalysis() -> SearchAnalysis? {
         guard !searchResults.isEmpty else { return nil }
         
         let query = BookSearchQuery(
@@ -306,17 +294,17 @@ public class RegisterModel {
 }
 
 /// 検索結果の分析データ
-public struct SearchAnalysis: Equatable, Sendable {
-    public let searchQuery: BookSearchQuery
-    public let totalResults: Int
-    public let highScoreCount: Int  // 0.8以上
-    public let mediumScoreCount: Int  // 0.5-0.8
-    public let lowScoreCount: Int  // 0.5未満
-    public let hasExactMatch: Bool  // 0.9以上の結果があるか
-    public let averageScore: Double
-    public let topResult: ScoredBook?
+struct SearchAnalysis: Equatable, Sendable {
+    let searchQuery: BookSearchQuery
+    let totalResults: Int
+    let highScoreCount: Int  // 0.8以上
+    let mediumScoreCount: Int  // 0.5-0.8
+    let lowScoreCount: Int  // 0.5未満
+    let hasExactMatch: Bool  // 0.9以上の結果があるか
+    let averageScore: Double
+    let topResult: ScoredBook?
     
-    public init(
+    init(
         searchQuery: BookSearchQuery,
         totalResults: Int,
         highScoreCount: Int,
@@ -337,7 +325,7 @@ public struct SearchAnalysis: Equatable, Sendable {
     }
     
     /// 検索品質の評価
-    public var searchQuality: SearchQuality {
+    var searchQuality: SearchQuality {
         if hasExactMatch {
             return .excellent
         } else if highScoreCount > 0 {
@@ -351,7 +339,7 @@ public struct SearchAnalysis: Equatable, Sendable {
 }
 
 /// 検索品質の評価
-public enum SearchQuality: String, CaseIterable, Sendable {
+enum SearchQuality: String, CaseIterable, Sendable {
     case excellent = "非常に良い"
     case good = "良い"
     case fair = "普通"

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/BookAutoFillContainerButton.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/BookAutoFillContainerButton.swift
@@ -1,32 +1,31 @@
 import PictureBookLendingDomain
 import PictureBookLendingInfrastructure
-import PictureBookLendingModel
 import PictureBookLendingUI
 import SwiftUI
 
 /// 絵本自動入力ボタンのContainer View
 ///
-/// RegisterModelを使用してビジネスロジックを処理し、
+/// BookRegisterViewModelを使用してビジネスロジックを処理し、
 /// BookAutoFillButtonに状態とアクションを提供します。
 struct BookAutoFillContainerButton: View {
     @Binding var targetBook: Book
     let onAutoFillComplete: (Book) -> Void
     
-    @State private var registerModel: RegisterModel
+    @State private var registerViewModel: BookRegisterViewModel
     @State private var isResultSheetPresented = false
     
     init(targetBook: Binding<Book>, onAutoFillComplete: @escaping (Book) -> Void) {
         self._targetBook = targetBook
         self.onAutoFillComplete = onAutoFillComplete
         
-        // RegisterModelを初期化
+        // BookRegisterViewModelを初期化
         let repositoryFactory = SwiftDataRepositoryFactory.shared
         let gateway = repositoryFactory.makeBookSearchGateway()
         let normalizer = GoogleBooksOptimizedNormalizer()
         let repository = repositoryFactory.makeBookRepository()
         
-        self._registerModel = State(
-            initialValue: RegisterModel(
+        self._registerViewModel = State(
+            initialValue: BookRegisterViewModel(
                 gateway: gateway,
                 normalizer: normalizer,
                 repository: repository
@@ -36,15 +35,15 @@ struct BookAutoFillContainerButton: View {
     
     var body: some View {
         BookAutoFillButton(
-            isSearching: registerModel.isSearching,
-            searchError: registerModel.searchError,
+            isSearching: registerViewModel.isSearching,
+            searchError: registerViewModel.searchError,
             onSearch: handleSearch
         )
         .sheet(isPresented: $isResultSheetPresented) {
             searchResultsSheet
                 .interactiveDismissDisabled()  // スワイプで閉じないように
         }
-        .onChange(of: registerModel.searchResults) { _, newResults in
+        .onChange(of: registerViewModel.searchResults) { _, newResults in
             if !newResults.isEmpty {
                 isResultSheetPresented = true
             }
@@ -54,11 +53,11 @@ struct BookAutoFillContainerButton: View {
     @ViewBuilder
     private var searchResultsSheet: some View {
         BookSearchResultsView(
-            searchResults: registerModel.searchResults,
+            searchResults: registerViewModel.searchResults,
             onBookSelect: selectBook,
             onCancel: {
                 isResultSheetPresented = false
-                registerModel.clearSearchResults()
+                registerViewModel.clearSearchResults()
             }
         )
     }
@@ -67,13 +66,13 @@ struct BookAutoFillContainerButton: View {
     
     private func handleSearch() {
         // BookFormViewのタイトルと著者名を使用して検索
-        registerModel.searchTitle = targetBook.title
-        registerModel.searchAuthor = targetBook.author ?? ""
+        registerViewModel.searchTitle = targetBook.title
+        registerViewModel.searchAuthor = targetBook.author ?? ""
         
         do {
-            try registerModel.searchBooks()
+            try registerViewModel.searchBooks()
         } catch {
-            // エラーはregisterModel.searchErrorに設定される
+            // エラーはregisterViewModel.searchErrorに設定される
         }
     }
     
@@ -100,7 +99,7 @@ struct BookAutoFillContainerButton: View {
         
         // UI状態をリセット
         isResultSheetPresented = false
-        registerModel.clearSearchResults()
+        registerViewModel.clearSearchResults()
     }
 }
 

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/BookBulkAddContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/BookBulkAddContainerView.swift
@@ -27,18 +27,18 @@ struct BookBulkAddContainerView: View {
     @State private var currentBookIndex = 0
     @State private var activeFailedBook: FailedBookItem?
     
-    // RegisterModelを使用して検索機能を利用
-    @State private var registerModel: RegisterModel
+    // BookRegisterViewModelを使用して検索機能を利用
+    @State private var registerViewModel: BookRegisterViewModel
     
     init() {
-        // RegisterModelを初期化
+        // BookRegisterViewModelを初期化
         let repositoryFactory = SwiftDataRepositoryFactory.shared
         let gateway = repositoryFactory.makeBookSearchGateway()
         let normalizer = GoogleBooksOptimizedNormalizer()
         let repository = repositoryFactory.makeBookRepository()
         
-        self._registerModel = State(
-            initialValue: RegisterModel(
+        self._registerViewModel = State(
+            initialValue: BookRegisterViewModel(
                 gateway: gateway,
                 normalizer: normalizer,
                 repository: repository
@@ -333,15 +333,15 @@ struct BookBulkAddContainerView: View {
     private func performSingleSearch(
         for entry: ParsedBookEntry, completion: @escaping (Book?) -> Void
     ) async {
-        // RegisterModelに検索条件をセット
-        registerModel.searchTitle = entry.inputTitle
-        registerModel.searchAuthor = ""
-        registerModel.clearSearchResults()
+        // BookRegisterViewModelに検索条件をセット
+        registerViewModel.searchTitle = entry.inputTitle
+        registerViewModel.searchAuthor = ""
+        registerViewModel.clearSearchResults()
         
         do {
-            try registerModel.searchBooks()
+            try registerViewModel.searchBooks()
             
-            // RegisterModelの状態変更を監視
+            // BookRegisterViewModelの状態変更を監視
             await withCheckedContinuation { continuation in
                 var isCompleted = false
                 
@@ -351,10 +351,10 @@ struct BookBulkAddContainerView: View {
                     let startTime = Date()
                     
                     while !isCompleted && Date().timeIntervalSince(startTime) < maxWaitTime {
-                        if !registerModel.isSearching {
+                        if !registerViewModel.isSearching {
                             // 検索完了
                             if let bestMatch = findBestMatch(
-                                for: entry.inputTitle, in: registerModel.searchResults)
+                                for: entry.inputTitle, in: registerViewModel.searchResults)
                             {
                                 completion(bestMatch.book)
                             } else {
@@ -378,10 +378,10 @@ struct BookBulkAddContainerView: View {
                 }
                 
                 // 初期状態で既に完了している場合の処理
-                if !registerModel.isSearching {
+                if !registerViewModel.isSearching {
                     monitorTask.cancel()
                     if let bestMatch = findBestMatch(
-                        for: entry.inputTitle, in: registerModel.searchResults)
+                        for: entry.inputTitle, in: registerViewModel.searchResults)
                     {
                         completion(bestMatch.book)
                     } else {

--- a/PictureBookLendingAdminApp/PictureBookLendingAdminTests/BookRegisterViewModelTests.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdminTests/BookRegisterViewModelTests.swift
@@ -1,11 +1,12 @@
 import Foundation
 import PictureBookLendingDomain
+import PictureBookLendingInfrastructure
 import Testing
 
-@testable import PictureBookLendingModel
+@testable import PictureBookLendingAdmin
 
-@Suite("RegisterModel Tests")
-struct RegisterModelTests {
+@Suite("BookRegisterViewModel Tests")
+struct BookRegisterViewModelTests {
     
     // MARK: - Test Data
     
@@ -40,10 +41,10 @@ struct RegisterModelTests {
     
     // MARK: - Initialization Tests
     
-    @Test("RegisterModelの初期化")
+    @Test("BookRegisterViewModelの初期化")
     @MainActor
     func testInitialization() {
-        let model = createRegisterModel()
+        let model = createViewModel()
         
         #expect(model.searchTitle == "")
         #expect(model.searchAuthor == "")
@@ -62,7 +63,7 @@ struct RegisterModelTests {
     @Test("検索実行可能性の判定")
     @MainActor
     func testCanSearch() {
-        let model = createRegisterModel()
+        let model = createViewModel()
         
         // 初期状態：検索不可
         #expect(model.canSearch == false)
@@ -98,7 +99,7 @@ struct RegisterModelTests {
     @Test("検索結果の選択")
     @MainActor
     func testSelectSearchResult() {
-        let model = createRegisterModel()
+        let model = createViewModel()
         let scoredBook = ScoredBook(book: sampleBooks[0], score: 0.9)
         
         model.selectSearchResult(scoredBook)
@@ -111,7 +112,7 @@ struct RegisterModelTests {
     @Test("検索結果のクリア")
     @MainActor
     func testClearSearchResults() {
-        let model = createRegisterModel()
+        let model = createViewModel()
         
         // 検索結果を設定
         model.searchResults = [ScoredBook(book: sampleBooks[0], score: 0.9)]
@@ -130,7 +131,7 @@ struct RegisterModelTests {
     @Test("手動入力モードへの切り替え")
     @MainActor
     func testSwitchToManualEntry() {
-        let model = createRegisterModel()
+        let model = createViewModel()
         
         // 検索入力を設定
         model.searchTitle = "テストタイトル"
@@ -152,7 +153,7 @@ struct RegisterModelTests {
     @Test("手動入力モードで著者が空の場合")
     @MainActor
     func testSwitchToManualEntryWithEmptyAuthor() {
-        let model = createRegisterModel()
+        let model = createViewModel()
         
         model.searchTitle = "テストタイトル"
         model.searchAuthor = ""
@@ -165,7 +166,7 @@ struct RegisterModelTests {
     @Test("検索結果モードへの切り替え")
     @MainActor
     func testSwitchToSearchResults() {
-        let model = createRegisterModel()
+        let model = createViewModel()
         
         // 手動入力モードに設定
         model.switchToManualEntry()
@@ -181,7 +182,7 @@ struct RegisterModelTests {
     @Test("手動入力の絵本情報更新")
     @MainActor
     func testUpdateManualBook() {
-        let model = createRegisterModel()
+        let model = createViewModel()
         let updatedBook = sampleBooks[0]
         
         model.updateManualBook(updatedBook)
@@ -194,7 +195,7 @@ struct RegisterModelTests {
     @Test("登録実行可能性の判定")
     @MainActor
     func testCanRegister() {
-        let model = createRegisterModel()
+        let model = createViewModel()
         
         // 初期状態：登録不可
         #expect(model.canRegister == false)
@@ -212,7 +213,7 @@ struct RegisterModelTests {
     @Test("登録対象の絵本取得")
     @MainActor
     func testBookToRegister() {
-        let model = createRegisterModel()
+        let model = createViewModel()
         
         // 初期状態：登録対象なし
         #expect(model.bookToRegister == nil)
@@ -232,7 +233,7 @@ struct RegisterModelTests {
     @Test("登録状態のリセット")
     @MainActor
     func testResetRegistrationState() {
-        let model = createRegisterModel()
+        let model = createViewModel()
         
         // 各種状態を設定
         model.searchTitle = "テストタイトル"
@@ -260,7 +261,7 @@ struct RegisterModelTests {
     @Test("検索分析の取得")
     @MainActor
     func testGetSearchAnalysis() {
-        let model = createRegisterModel()
+        let model = createViewModel()
         
         // 検索結果なしの場合
         #expect(model.getSearchAnalysis() == nil)
@@ -344,12 +345,12 @@ struct RegisterModelTests {
     // MARK: - Helper Methods
     
     @MainActor
-    private func createRegisterModel() -> RegisterModel {
+    private func createViewModel() -> BookRegisterViewModel {
         let mockGateway = MockBookSearchGateway()
         let normalizer = MockStringNormalizer()
         let repository = MockBookRepository()
         
-        return RegisterModel(
+        return BookRegisterViewModel(
             gateway: mockGateway,
             normalizer: normalizer,
             repository: repository


### PR DESCRIPTION
Closes #196

このPRは他のリファクタPRチェーン（#197→#198→…）とは**独立**で、いつでもレビュー・マージ可能です。

## 概要

Model層に居た `RegisterModel` は、中身が `searchTitle` / `isSearching` / `selectedResult` / `isManualEntryMode` 等の「絵本登録画面の画面状態」であり、アプリ全域Model（BookModel等5つ・@Environment配布）とは寿命も役割も異なります。新ルール「画面スコープの@Observable = 〜ViewModel（App層）」に沿って移設・改名します。

## 変更内容

- `PictureBookLendingModel/Sources/RegisterModel.swift` → `PictureBookLendingAdmin/ViewModels/BookRegisterViewModel.swift`（App層に `ViewModels/` 新設）
  - `RegisterModel` → `BookRegisterViewModel`、`RegisterModelError` → `BookRegisterViewModelError`
  - App層内でのみ使うため `public` → `internal`
  - `#if DEBUG` のデバッグprint（🔍 canSearch check等）を削除
- テスト移設: `RegisterModelTests` → `PictureBookLendingAdminTests/BookRegisterViewModelTests`（13テスト・内容不変）
- 利用箇所更新: `BookAutoFillContainerButton` / `BookBulkAddContainerView`
- **CLAUDE.md**: 「状態管理の分類」直後に「状態の所有権ルール（Container間の状態共有）」と「状態を持つ型の命名・配置」を追記

## レビューポイント

- 命名: `BookRegisterViewModelError` はやや冗長かも。`BookRegisterError` 等への短縮もアリです（ご指定あれば直します）
- CLAUDE.md追記ルールの文面

## テスト

- Model層単体: swift build / swift test 成功（46テスト・RegisterModel削除後も無傷）
- 全体ビルド: BUILD SUCCEEDED
- 全テスト（iPad Pro 13-inch (M5) シミュレータ）: 119テスト全パス（新BookRegisterViewModelTests 13件の実行をxcresultで確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)