### PR TITLE
fix: LoanFormatterTestsのタイムゾーン依存を解消（CIの慢性的な単体テスト失敗の根治）

### DIFF
--- a/PictureBookLendingAdminApp/PictureBookLendingAdminTests/LoanFormatterTests.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdminTests/LoanFormatterTests.swift
@@ -5,15 +5,18 @@ import XCTest
 
 final class LoanFormatterTests: XCTestCase {
     
-    /// 2026年6月20日（土）12:00 JST の Date を生成する
+    /// 2026年6月20日（土）12:00 の Date を生成する
+    ///
+    /// `dueDateText` は実行環境の現在タイムゾーンで整形されるため、
+    /// 期待値と日付がズレないよう現在のタイムゾーンで組み立てる
+    /// （JST固定にするとCI（米国太平洋時間）で6月19日(金)に整形されて失敗する）
     private func makeDate() -> Date {
         var components = DateComponents()
         components.year = 2026
         components.month = 6
         components.day = 20
         components.hour = 12
-        var calendar = Calendar(identifier: .gregorian)
-        calendar.timeZone = TimeZone(identifier: "Asia/Tokyo")!
+        let calendar = Calendar(identifier: .gregorian)
         return calendar.date(from: components)!
     }
     


### PR DESCRIPTION
## 概要

Xcode Cloudの「PR時に単体テスト」が全PRで慢性的に失敗していた原因の修正です。

## 原因

- テストは「2026年6月20日 12:00 **JST**」（Asia/Tokyo固定）のDateを作る
- `Loan.dueDateText` は**実行マシンの現在タイムゾーン**で整形する
- Xcode Cloudは米国太平洋時間で動くため、JSTの6/20 12:00 → PDTでは6/19 20:00となり「**6月19日(金)**」に整形され、「6月20日」「土」を含まず失敗

```
XCTAssertTrue failed - 月日が日本語表記で含まれる: 6月19日(金)
XCTAssertTrue failed - 曜日が含まれる: 6月19日(金)
```

ローカル（JST）では絶対に再現しない、時差だけで落ちるテストでした。

## 修正

テスト側の日付組み立てをJST固定→実行環境の現在タイムゾーンに変更（`dueDateText`の整形タイムゾーンと一致させる）。アプリ本体のコードは触っていません。

## テスト

- 全テスト（iPad Pro 13-inch (M5) シミュレータ）: TEST SUCCEEDED
- マージ後、他のPRをrebaseすればCIは緑になる見込み

🤖 Generated with [Claude Code](https://claude.com/claude-code)