### PR TITLE
fix: iOS 27実機でかなチップが表示されない不具合を修正（ScrollView廃止）

### DIFF
--- a/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/Book/BookListView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/Book/BookListView.swift
@@ -202,9 +202,14 @@ public struct BookListView<RowAction: View>: View {
     private var kanaFilterSection: some View {
         HStack {
             if isKanaChipsVisible {
-                ScrollView(.horizontal) {
+                // iOS 27ベータにHStack内の横ScrollViewが幅0のまま描画されない不具合があるため、
+                // ScrollViewを使わず素のHStackで並べる（チップは全iPadのregular幅に収まる）。
+                // 収まらない幅（狭いSplit View等）ではcompact時と同じ思想でチップを出さない
+                ViewThatFits(in: .horizontal) {
                     kanaChips
                         .padding(.leading)
+                    Color.clear
+                        .frame(width: 0, height: 0)
                 }
             }
             


### PR DESCRIPTION
## 概要

iOS 27ベータ（24A5370h）の実機で、貸出タブのかなチップが表示されない不具合の修正です。

## 原因調査の経緯

実機にデバッグログを仕込んで切り分けた結果:

- `horizontalSizeClass` = regular（表示ゲートは開いている）→ sizeClass説は無罪
- 文字サイズ（Dynamic Type）も無関係（実機で検証済み）
- **`ScrollView(.horizontal)` の実測幅が一瞬0ptになるログを確認**。同一コードがシミュレータでは正常表示、実機ベータでは非表示
- ScrollViewを外すと実機で表示が復活（検証済み）

→ HStack内の横ScrollViewの幅ネゴシエーションがベータOSで幅0のまま固まる描画不具合と断定。

## 修正

- `ScrollView(.horizontal)` を廃止し、素のHStack（`kanaChips`）を直接配置
- チップ11個（あ〜他）は全iPadのregular幅に収まることをiPad mini（最狭ケース）で確認済み
- 収まらない幅（13インチの50:50 Split View等）では `ViewThatFits` でチップを非表示（compact時と同じ「検索を主動線とする」思想）

## テスト

- 全テスト（iPad Air 13-inch (M3) シミュレータ）: TEST SUCCEEDED
- iPad miniシミュレータでチップ11個の収まりをスクリーンショット確認
- iOS 27ベータ実機（iPad mini 6）で表示復活を確認済み

## 備考

実機確認済みですが、UXが本質の画面なのでマージ前にもう一度実機で最終確認を推奨します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)