### PR TITLE
refactor: PRチェーン(#198・#200・#201)の内容をmainへ統合

### DIFF
--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/ContentView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/ContentView.swift
@@ -9,6 +9,12 @@ import SwiftUI
 /// - 貸出 - 図書一覧から貸出操作を行う（既定タブ）
 /// - 返却 - 貸出中の利用者一覧から返却操作を行う
 struct ContentView: View {
+    @Environment(\.scenePhase) private var scenePhase
+    @Environment(BookModel.self) private var bookModel
+    @Environment(UserModel.self) private var userModel
+    @Environment(LoanModel.self) private var loanModel
+    @Environment(ClassGroupModel.self) private var classGroupModel
+    
     // 選択中のタブを管理（DEBUG/リリースとも貸出タブを初期表示）
     @State private var selectedTab = 0
     
@@ -40,6 +46,28 @@ struct ContentView: View {
                 .tag(2)
             #endif
         }
+        // 各Modelは配列をキャッシュするため、他画面での変更に自動では気づかない。
+        // 画面ごとに個別のrefreshを当て続けると付け忘れによる古いデータ表示バグが起きやすいので、
+        // タブルートで全Modelを一括リフレッシュする（500冊/200ユーザ規模では全refreshも一瞬）。
+        .onAppear {
+            refreshAllModels()
+        }
+        .onChange(of: selectedTab) {
+            refreshAllModels()
+        }
+        .onChange(of: scenePhase) { _, newPhase in
+            // フォアグラウンド復帰時に最新化する
+            if newPhase == .active {
+                refreshAllModels()
+            }
+        }
+    }
+    
+    private func refreshAllModels() {
+        bookModel.refreshBooks()
+        userModel.refreshUsers()
+        loanModel.refreshLoans()
+        classGroupModel.refreshClassGroups()
     }
 }
 

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/SettingsBookListContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/SettingsBookListContainerView.swift
@@ -90,10 +90,6 @@ struct SettingsBookListContainerView: View {
         } message: {
             Text(alertState.message)
         }
-        .onAppear {
-            bookModel.refreshBooks()
-            loanModel.refreshLoans()
-        }
         .refreshable {
             bookModel.refreshBooks()
             loanModel.refreshLoans()

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Borrow/BorrowListContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Borrow/BorrowListContainerView.swift
@@ -242,7 +242,6 @@ struct BorrowListContainerView: View {
                     }
                     
                     FamilyLoanSlotsContainerView(
-                        alertState: $alertState,
                         undoFeedback: $undoFeedback,
                         userId: route.userId,
                         context: .borrowing(onSlotSelected: { slotUserId in

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Borrow/BorrowListContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Borrow/BorrowListContainerView.swift
@@ -124,9 +124,6 @@ struct BorrowListContainerView: View {
                 }
             #endif
         }
-        .onAppear {
-            refreshData()
-        }
         .refreshable {
             refreshData()
         }

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Borrow/BorrowListContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Borrow/BorrowListContainerView.swift
@@ -9,7 +9,8 @@ import SwiftUI
 /// 本起点の3タップ貸出フローを提供します。
 /// 図書一覧で本をタップすると、フォームシートが開き
 /// 「だれが借りますか？」（利用者選択）→「どの枠で借りますか？」（家庭の枠確認）
-/// → ✓カード の順にシートの中だけで完結します。背後の図書一覧は動きません。
+/// → ✓カード の順にシートの中だけで完結します（シートの中身は`BorrowSheetContainerView`）。
+/// 背後の図書一覧は動きません。
 /// 貸出が終わる（✓カードが消える）と、または置き去り復帰時にはシートを閉じます。
 /// 返却モードで確立したパターン（カード表示中は留まり消えたら戻る・
 /// 無操作15秒で置き去り復帰）を踏襲します。
@@ -29,40 +30,14 @@ struct BorrowListContainerView: View {
     /// その瞬間に値が反転し、シートの土台（フォームシート/ページシートの分岐、
     /// 案内画面/名前一覧の分岐）ごと作り直されて✓カードが一瞬で消えてしまうため
     @State private var borrowSheetContext: BorrowSheetContext?
-    /// フォームシート内部の遷移パス（利用者選択→枠確認）
-    @State private var sheetPath = NavigationPath()
-    /// 利用者選択画面で組チップにより絞り込み中の組ID（nilなら全組）
-    @State private var selectedClassGroupId: UUID?
     /// 図書一覧の絞り込み状態（検索テキスト・五十音フィルタ。両者は排他制御される）
     @State private var filterState = BookListFilterState()
     /// 図書一覧をトップへ戻すトリガ（貸出完了ごとにインクリメント）
     @State private var scrollToTopTrigger = 0
     @State private var selectedSortType: BookSortType = .title
     @State private var displayMode: BookDisplayMode = .grid
-    @State private var alertState = AlertState()
-    @State private var successFeedback = SuccessFeedback()
-    /// 貸出後、✓カードの表示が終わったらシートを閉じる（図書一覧へ戻す）ための予約フラグ
-    @State private var isPopPendingAfterLend = false
-    /// 選択画面の無操作タイマーのトークン（操作のたびに更新して待ち時間を延長する）
-    @State private var idleTicket = 0
-    /// 枠確認画面での返却（本の入れ替え）用のUndoカード状態
-    @State private var undoFeedback = UndoFeedback()
     /// 設定画面表示状態
     @State private var isSettingsPresented = false
-    
-    /// 貸出成功の✓カードの表示時間。カードの消滅がシートを閉じる合図を兼ねるため、
-    /// 既定の1.5秒では読み切る前に画面が変わってしまう。読み切れる長さに延ばす
-    private static let lendFeedbackDuration: Duration = .seconds(2.5)
-    
-    private enum Layout {
-        static let sectionSpacing: CGFloat = 24
-        static let headerContentSpacing: CGFloat = 16
-        static let headerTextSpacing: CGFloat = 4
-        /// 表紙サムネイル（家庭の枠の貸出中カードと同じ寸法で揃える）
-        static let thumbnailWidth: CGFloat = 56
-        static let thumbnailHeight: CGFloat = 72
-        static let thumbnailCornerRadius: CGFloat = 6
-    }
     
     var body: some View {
         NavigationStack {
@@ -133,154 +108,25 @@ struct BorrowListContainerView: View {
             // 一回り大きいシステム標準のページシートで出す。
             // 判定はitemに焼き込んだスナップショットを使う（理由は`borrowSheetContext`参照）
             if context.isAlreadyLent {
-                borrowSheetContent(for: context)
+                borrowSheet(for: context)
                     .presentationSizing(.form)
             } else {
-                borrowSheetContent(for: context)
+                borrowSheet(for: context)
                     .presentationSizing(.page)
             }
         }
     }
     
-    /// 貸出シートの中身（利用者選択→枠確認→✓カード）
+    /// 貸出シート（子Container）。シート内フローの状態はすべて子の@Stateが持つ。
     ///
-    /// 一時的な貸出タスクをシートの中だけで完結させる。
-    /// ✓カードとアラートは背後の図書一覧に付けると隠れるため、必ずシート内に置く
-    private func borrowSheetContent(for context: BorrowSheetContext) -> some View {
-        NavigationStack(path: $sheetPath) {
-            borrowerPickScreen(for: context)
-                .navigationDestination(for: BorrowConfirmRoute.self) { route in
-                    slotConfirmScreen(for: route)
-                }
-        }
-        .alert(alertState.title, isPresented: $alertState.isPresented) {
-            Button("OK", role: .cancel) {}
-        } message: {
-            Text(alertState.message)
-        }
-        .successFeedback($successFeedback, displayDuration: Self.lendFeedbackDuration)
-        // 枠確認画面での返却（本の入れ替え）に対するUndoカード。
-        // 取り消してもその場に留まり、枠に本が戻るのを見せる
-        .undoFeedback($undoFeedback, onUndo: handleUndoReturn)
-        .onChange(of: successFeedback.isPresented) { wasPresented, isPresented in
-            // ✓カードがタイムアウトで消えたらシートを閉じる
-            if wasPresented && !isPresented && isPopPendingAfterLend {
-                isPopPendingAfterLend = false
-                borrowSheetContext = nil
-                // 貸出完了→次の貸出のために絞り込みを解除し、図書一覧を先頭へ戻す
-                filterState.reset()
-                scrollToTopTrigger += 1
-            }
-        }
-        // 誤スワイプで貸出タスクが途中で消えないようにする（閉じるのは✕ボタンから。
-        // 絵本管理の貸出フォームと同じ作法）
-        .interactiveDismissDisabled()
-    }
-    
-    // MARK: - Private Views
-    
-    /// 利用者選択画面（フォームシートの最初の画面・「だれが借りますか？」）
-    ///
-    /// 貸出中の図書が選ばれた場合は貸出できない理由を説明する空状態を表示する。
-    /// 判定はitemに焼き込んだスナップショットを使う（理由は`borrowSheetContext`参照）
-    private func borrowerPickScreen(for context: BorrowSheetContext) -> some View {
-        sheetScreen(title: "だれが借りますか？") {
-            if context.isAlreadyLent {
-                ContentUnavailableView(
-                    "この図書は貸出中です",
-                    systemImage: "book.closed",
-                    description: Text(lentBookDescription(for: context.book))
-                )
-            } else {
-                BorrowerListView(
-                    sections: allUserSections,
-                    // 自分の組が分かっていて切り替えたい画面なので、
-                    // チップはインデックスではなくフィルタとして動作させる
-                    chipBehavior: .filter(selection: $selectedClassGroupId),
-                    emptyStateTitle: "利用者が登録されていません",
-                    emptyStateDescription: "設定画面から利用者を登録してください",
-                    onSelect: { row in
-                        sheetPath.append(BorrowConfirmRoute(book: context.book, userId: row.id))
-                    }
-                )
-            }
-        }
-    }
-    
-    /// 枠確認画面（シート内で利用者タップから進む先・「どの枠で借りますか？」）
-    ///
-    /// 選んだ図書の要約（表紙＋タイトル＋著者）を上部に示し、
-    /// 家庭の枠領域（貸出文脈）で空き枠を選ばせる。
-    /// 表紙の見た目は家庭の枠の貸出中カードと同じ作法（サイズ・角丸）で揃える
-    private func slotConfirmScreen(for route: BorrowConfirmRoute) -> some View {
-        sheetScreen(title: "どの枠で借りますか？") {
-            ScrollView {
-                VStack(alignment: .leading, spacing: Layout.sectionSpacing) {
-                    HStack(spacing: Layout.headerContentSpacing) {
-                        BookImageView(imageURL: route.book.resolvedSmallImageSource) {
-                            Image(systemName: "book.closed")
-                                .foregroundStyle(.secondary)
-                                .font(.title2)
-                        }
-                        .aspectRatio(contentMode: .fit)
-                        .frame(width: Layout.thumbnailWidth, height: Layout.thumbnailHeight)
-                        .background(.regularMaterial)
-                        .clipShape(RoundedRectangle(cornerRadius: Layout.thumbnailCornerRadius))
-                        
-                        VStack(alignment: .leading, spacing: Layout.headerTextSpacing) {
-                            Text("『\(route.book.title)』")
-                                .font(.title3.bold())
-                            if let author = route.book.author {
-                                Text(author)
-                                    .font(.subheadline)
-                                    .foregroundStyle(.secondary)
-                            }
-                        }
-                    }
-                    
-                    FamilyLoanSlotsContainerView(
-                        undoFeedback: $undoFeedback,
-                        userId: route.userId,
-                        context: .borrowing(onSlotSelected: { slotUserId in
-                            handleLend(book: route.book, userId: slotUserId)
-                        })
-                    )
-                }
-                .padding()
-            }
-        }
-    }
-    
-    /// シート内画面の共通装飾（無操作タイマー・インラインタイトル・✕閉じるボタン）
-    ///
-    /// ✕ボタンは、下スワイプでの閉じ方を知らない利用者のための明示的な閉じる手段
-    private func sheetScreen(
-        title: String,
-        @ViewBuilder content: () -> some View
-    ) -> some View {
-        content()
-            // コンテンツ領域のタッチ（タップ・スクロール）で無操作タイマーを延長する。
-            // 200人の一覧をゆっくり探している最中に置き去り扱いで閉じないようにする。
-            // ナビバー（戻る・✕）には掛けない：バーのボタンのタッチと競合して
-            // 戻るボタンが効かなくなるため、コンテンツにだけ付ける
-            .simultaneousGesture(
-                DragGesture(minimumDistance: 0)
-                    .onEnded { _ in idleTicket += 1 }
-            )
-            .kioskIdleTimeout(ticket: idleTicket) { borrowSheetContext = nil }
-            .navigationTitle(title)
-            #if os(iOS)
-                .navigationBarTitleDisplayMode(.inline)
-                .toolbar {
-                    ToolbarItem(placement: .topBarTrailing) {
-                        Button {
-                            borrowSheetContext = nil
-                        } label: {
-                            Image(systemName: "xmark")
-                        }
-                    }
-                }
-            #endif
+    /// シート表示ごとに子が生成・破棄されるため、遷移パスや組の絞り込みは
+    /// 毎回初期値から始まる（親側での手動リセットは不要）。
+    private func borrowSheet(for context: BorrowSheetContext) -> some View {
+        BorrowSheetContainerView(
+            context: context,
+            onClose: { borrowSheetContext = nil },
+            onLendCompleted: handleLendCompleted
+        )
     }
     
     // MARK: - Computed Properties
@@ -308,102 +154,27 @@ struct BorrowListContainerView: View {
         )
     }
     
-    /// 利用者選択画面の組セクション（組ごとに名前順）
-    ///
-    /// 一覧から隠すのは「別の入口から構造的に到達できる利用者」＝保護者だけ
-    /// （保護者の枠は園児タップ後の家庭の画面から必ず選べる。IA_REVIEW 追記12）。
-    /// 園児と、大人の組の独立利用者（先生・職員）はそのまま表示する。
-    /// 紐づく園児が実在しない保護者は入口を失うため、本人を表示するフォールバック。
-    /// 家庭の全員が借用中の行には「空き枠なし」バッジを付け、タップ前に結果を知らせる。
-    /// 一覧に出す利用者の判定は`userModel.getFamilyEntranceUsers()`に委譲する。
-    private var allUserSections: [BorrowerListSection] {
-        let allUsers = userModel.getAllUsers()
-        let entranceUsers = userModel.getFamilyEntranceUsers()
-        
-        // 空き枠判定の材料：借用中の利用者IDと、園児→紐づく保護者の対応表
-        let borrowedUserIds = Set(loanModel.activeLoans.map { $0.user.id })
-        var guardiansByChildId: [UUID: [User]] = [:]
-        for user in allUsers {
-            if case .guardian(let relatedChildId) = user.userType {
-                guardiansByChildId[relatedChildId, default: []].append(user)
-            }
-        }
-        
-        return Dictionary(grouping: entranceUsers) { $0.classGroupId }
-            .map { classGroupId, users in
-                BorrowerListSection(
-                    id: classGroupId,
-                    title: classGroupModel.findClassGroupById(classGroupId)?.name ?? "未分類",
-                    rows:
-                        users
-                        .sorted { $0.name < $1.name }
-                        .map { user in
-                            // 家庭の全員（本人＋紐づく保護者）が借用中なら空き枠なし
-                            let familyMembers = [user] + (guardiansByChildId[user.id] ?? [])
-                            return BorrowerRowDisplay(
-                                id: user.id,
-                                name: user.name,
-                                isGuardian: user.userType.category == .guardian,
-                                isOverdue: false,
-                                hasNoOpenSlot: familyMembers.allSatisfy {
-                                    borrowedUserIds.contains($0.id)
-                                }
-                            )
-                        }
-                )
-            }
-            .sorted { $0.title < $1.title }
-    }
-    
-    /// 貸出中の図書の説明文（「いつ戻るか」の目安を日付だけで知らせる）
-    ///
-    /// 誰が借りているかは表示しない（プライバシー配慮・IA_REVIEW 追記13）
-    private func lentBookDescription(for book: Book) -> String {
-        if let loan = loanModel.getCurrentLoan(bookId: book.id) {
-            "\(loan.dueDateText)ごろ返却予定です"
-        } else {
-            "返却されると貸出できるようになります"
-        }
-    }
-    
     // MARK: - Actions
-    
-    /// 枠確認画面での返却の取り消し（Undoカードの「元に戻す」）
-    ///
-    /// 取り消したらその場に留まり、枠に本が戻るのを見せる
-    private func handleUndoReturn() {
-        guard let loanId = undoFeedback.targetId else { return }
-        do {
-            try loanModel.undoReturn(loanId: loanId)
-        } catch {
-            alertState = .error("返却の取り消しに失敗しました", message: error.localizedDescription)
-        }
-    }
     
     /// 図書の貸出シートを開く（行タップ・「借りる」ボタンの共通入口）
     ///
     /// 一覧はプッシュ遷移させず、その図書の貸出シートを開く。
-    /// 組の絞り込みも毎回リセットし、前の家庭の絞り込みを次の利用者に残さない
+    /// シート内フローの状態は子Container（`BorrowSheetContainerView`）の@Stateに任せるため、
+    /// ここでは提示単位（図書＋貸出状態のスナップショット）を差し込むだけでよい。
     private func openBorrowSheet(for book: Book) {
-        sheetPath = NavigationPath()
-        selectedClassGroupId = nil
         borrowSheetContext = BorrowSheetContext(
             book: book,
             isAlreadyLent: loanModel.isBookLent(bookId: book.id)
         )
     }
     
-    /// 貸出の実行（枠選択のタップで確定・✓カードで完了を伝える）
-    private func handleLend(book: Book, userId: UUID) {
-        do {
-            _ = try loanModel.lendBook(bookId: book.id, userId: userId)
-            let name = userModel.findUserById(userId)?.name ?? ""
-            successFeedback.show("\(name)さんに『\(book.title)』を貸出しました")
-            isPopPendingAfterLend = true
-            idleTicket += 1
-        } catch {
-            alertState = .error("貸出に失敗しました", message: error.localizedDescription)
-        }
+    /// 貸出完了（✓カードが消えた）ときの後始末。
+    ///
+    /// シートを閉じ、次の貸出のために絞り込みを解除して図書一覧を先頭へ戻す
+    private func handleLendCompleted() {
+        borrowSheetContext = nil
+        filterState.reset()
+        scrollToTopTrigger += 1
     }
     
     private func refreshData() {
@@ -417,17 +188,11 @@ struct BorrowListContainerView: View {
 /// 貸出シートの提示単位（選んだ図書＋開いた時点の貸出状態のスナップショット）
 ///
 /// 貸出状態を図書と同じitemに焼き込むことで、シート提示時に両者がズレないことを保証する
-private struct BorrowSheetContext: Identifiable {
+struct BorrowSheetContext: Identifiable {
     let book: Book
     let isAlreadyLent: Bool
     
     var id: UUID { book.id }
-}
-
-/// 枠確認画面への遷移値（選んだ図書＋家庭を特定する利用者ID）
-private struct BorrowConfirmRoute: Hashable {
-    let book: Book
-    let userId: UUID
 }
 
 #Preview {

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Borrow/BorrowSheetContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Borrow/BorrowSheetContainerView.swift
@@ -1,0 +1,322 @@
+import PictureBookLendingDomain
+import PictureBookLendingInfrastructure
+import PictureBookLendingModel
+import PictureBookLendingUI
+import SwiftUI
+
+/// 貸出シートのContainer View（図書一覧から開く子シート）
+///
+/// 一時的な貸出タスク（「だれが借りますか？」→「どの枠で借りますか？」→ ✓カード）を
+/// シートの中だけで完結させる。シート表示ごとに@Stateごと生成・破棄されるため、
+/// 遷移パスや組の絞り込みは初期値（空・全組）から必ず始まる。前回の貸出の状態は残らない。
+///
+/// このViewの@State（`sheetPath`・`selectedClassGroupId`・各種フィードバック等）は
+/// すべてシート内フロー専用。「画面の境界＝状態の境界」に従い、
+/// 図書一覧（親）の状態とは混ぜない。
+///
+/// 親への通知はクロージャで最小限に：
+/// - `onClose`: ✕ボタン・無操作タイムアウトでシートを閉じるだけ
+/// - `onLendCompleted`: ✓カードが消えた後、シートを閉じて次の貸出へ引き継ぐ
+///   （図書一覧の絞り込み解除・先頭スクロールは親側の状態なので親に委ねる）
+struct BorrowSheetContainerView: View {
+    @Environment(LoanModel.self) private var loanModel
+    @Environment(UserModel.self) private var userModel
+    @Environment(ClassGroupModel.self) private var classGroupModel
+    
+    /// フォームシート内部の遷移パス（利用者選択→枠確認）
+    @State private var sheetPath = NavigationPath()
+    /// 利用者選択画面で組チップにより絞り込み中の組ID（nilなら全組）
+    @State private var selectedClassGroupId: UUID?
+    @State private var alertState = AlertState()
+    @State private var successFeedback = SuccessFeedback()
+    /// 貸出後、✓カードの表示が終わったらシートを閉じる（図書一覧へ戻す）ための予約フラグ
+    @State private var isPopPendingAfterLend = false
+    /// 選択画面の無操作タイマーのトークン（操作のたびに更新して待ち時間を延長する）
+    @State private var idleTicket = 0
+    /// 枠確認画面での返却（本の入れ替え）用のUndoカード状態
+    @State private var undoFeedback = UndoFeedback()
+    
+    /// タップされた図書と開いた時点の貸出状態のスナップショット（シートの提示単位）
+    let context: BorrowSheetContext
+    /// シートを閉じるだけの要求（✕ボタン・無操作タイムアウト）
+    let onClose: () -> Void
+    /// 貸出が完了し✓カードも消えたときの通知（親が図書一覧を次の貸出へ引き継ぐ）
+    let onLendCompleted: () -> Void
+    
+    /// 貸出成功の✓カードの表示時間。カードの消滅がシートを閉じる合図を兼ねるため、
+    /// 既定の1.5秒では読み切る前に画面が変わってしまう。読み切れる長さに延ばす
+    private static let lendFeedbackDuration: Duration = .seconds(2.5)
+    
+    private enum Layout {
+        static let sectionSpacing: CGFloat = 24
+        static let headerContentSpacing: CGFloat = 16
+        static let headerTextSpacing: CGFloat = 4
+        /// 表紙サムネイル（家庭の枠の貸出中カードと同じ寸法で揃える）
+        static let thumbnailWidth: CGFloat = 56
+        static let thumbnailHeight: CGFloat = 72
+        static let thumbnailCornerRadius: CGFloat = 6
+    }
+    
+    var body: some View {
+        NavigationStack(path: $sheetPath) {
+            borrowerPickScreen(for: context)
+                .navigationDestination(for: BorrowConfirmRoute.self) { route in
+                    slotConfirmScreen(for: route)
+                }
+        }
+        .alert(alertState.title, isPresented: $alertState.isPresented) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(alertState.message)
+        }
+        .successFeedback($successFeedback, displayDuration: Self.lendFeedbackDuration)
+        // 枠確認画面での返却（本の入れ替え）に対するUndoカード。
+        // 取り消してもその場に留まり、枠に本が戻るのを見せる
+        .undoFeedback($undoFeedback, onUndo: handleUndoReturn)
+        .onChange(of: successFeedback.isPresented) { wasPresented, isPresented in
+            // ✓カードがタイムアウトで消えたらシートを閉じる
+            if wasPresented && !isPresented && isPopPendingAfterLend {
+                isPopPendingAfterLend = false
+                // 貸出完了→次の貸出のために親へ通知（絞り込み解除・先頭スクロールは親側の状態）
+                onLendCompleted()
+            }
+        }
+        // 誤スワイプで貸出タスクが途中で消えないようにする（閉じるのは✕ボタンから。
+        // 絵本管理の貸出フォームと同じ作法）
+        .interactiveDismissDisabled()
+    }
+    
+    // MARK: - Private Views
+    
+    /// 利用者選択画面（フォームシートの最初の画面・「だれが借りますか？」）
+    ///
+    /// 貸出中の図書が選ばれた場合は貸出できない理由を説明する空状態を表示する。
+    /// 判定はitemに焼き込んだスナップショットを使う（理由は`BorrowSheetContext`参照）
+    private func borrowerPickScreen(for context: BorrowSheetContext) -> some View {
+        sheetScreen(title: "だれが借りますか？") {
+            if context.isAlreadyLent {
+                ContentUnavailableView(
+                    "この図書は貸出中です",
+                    systemImage: "book.closed",
+                    description: Text(lentBookDescription(for: context.book))
+                )
+            } else {
+                BorrowerListView(
+                    sections: allUserSections,
+                    // 自分の組が分かっていて切り替えたい画面なので、
+                    // チップはインデックスではなくフィルタとして動作させる
+                    chipBehavior: .filter(selection: $selectedClassGroupId),
+                    emptyStateTitle: "利用者が登録されていません",
+                    emptyStateDescription: "設定画面から利用者を登録してください",
+                    onSelect: { row in
+                        sheetPath.append(BorrowConfirmRoute(book: context.book, userId: row.id))
+                    }
+                )
+            }
+        }
+    }
+    
+    /// 枠確認画面（シート内で利用者タップから進む先・「どの枠で借りますか？」）
+    ///
+    /// 選んだ図書の要約（表紙＋タイトル＋著者）を上部に示し、
+    /// 家庭の枠領域（貸出文脈）で空き枠を選ばせる。
+    /// 表紙の見た目は家庭の枠の貸出中カードと同じ作法（サイズ・角丸）で揃える
+    private func slotConfirmScreen(for route: BorrowConfirmRoute) -> some View {
+        sheetScreen(title: "どの枠で借りますか？") {
+            ScrollView {
+                VStack(alignment: .leading, spacing: Layout.sectionSpacing) {
+                    HStack(spacing: Layout.headerContentSpacing) {
+                        BookImageView(imageURL: route.book.resolvedSmallImageSource) {
+                            Image(systemName: "book.closed")
+                                .foregroundStyle(.secondary)
+                                .font(.title2)
+                        }
+                        .aspectRatio(contentMode: .fit)
+                        .frame(width: Layout.thumbnailWidth, height: Layout.thumbnailHeight)
+                        .background(.regularMaterial)
+                        .clipShape(RoundedRectangle(cornerRadius: Layout.thumbnailCornerRadius))
+                        
+                        VStack(alignment: .leading, spacing: Layout.headerTextSpacing) {
+                            Text("『\(route.book.title)』")
+                                .font(.title3.bold())
+                            if let author = route.book.author {
+                                Text(author)
+                                    .font(.subheadline)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                    }
+                    
+                    FamilyLoanSlotsContainerView(
+                        undoFeedback: $undoFeedback,
+                        userId: route.userId,
+                        context: .borrowing(onSlotSelected: { slotUserId in
+                            handleLend(book: route.book, userId: slotUserId)
+                        })
+                    )
+                }
+                .padding()
+            }
+        }
+    }
+    
+    /// シート内画面の共通装飾（無操作タイマー・インラインタイトル・✕閉じるボタン）
+    ///
+    /// ✕ボタンは、下スワイプでの閉じ方を知らない利用者のための明示的な閉じる手段
+    private func sheetScreen(
+        title: String,
+        @ViewBuilder content: () -> some View
+    ) -> some View {
+        content()
+            // コンテンツ領域のタッチ（タップ・スクロール）で無操作タイマーを延長する。
+            // 200人の一覧をゆっくり探している最中に置き去り扱いで閉じないようにする。
+            // ナビバー（戻る・✕）には掛けない：バーのボタンのタッチと競合して
+            // 戻るボタンが効かなくなるため、コンテンツにだけ付ける
+            .simultaneousGesture(
+                DragGesture(minimumDistance: 0)
+                    .onEnded { _ in idleTicket += 1 }
+            )
+            .kioskIdleTimeout(ticket: idleTicket) { onClose() }
+            .navigationTitle(title)
+            #if os(iOS)
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .topBarTrailing) {
+                        Button {
+                            onClose()
+                        } label: {
+                            Image(systemName: "xmark")
+                        }
+                    }
+                }
+            #endif
+    }
+    
+    // MARK: - Computed Properties
+    
+    /// 利用者選択画面の組セクション（組ごとに名前順）
+    ///
+    /// 一覧から隠すのは「別の入口から構造的に到達できる利用者」＝保護者だけ
+    /// （保護者の枠は園児タップ後の家庭の画面から必ず選べる。IA_REVIEW 追記12）。
+    /// 園児と、大人の組の独立利用者（先生・職員）はそのまま表示する。
+    /// 紐づく園児が実在しない保護者は入口を失うため、本人を表示するフォールバック。
+    /// 家庭の全員が借用中の行には「空き枠なし」バッジを付け、タップ前に結果を知らせる。
+    /// 一覧に出す利用者の判定は`userModel.getFamilyEntranceUsers()`に委譲する。
+    private var allUserSections: [BorrowerListSection] {
+        let allUsers = userModel.getAllUsers()
+        let entranceUsers = userModel.getFamilyEntranceUsers()
+        
+        // 空き枠判定の材料：借用中の利用者IDと、園児→紐づく保護者の対応表
+        let borrowedUserIds = Set(loanModel.activeLoans.map { $0.user.id })
+        var guardiansByChildId: [UUID: [User]] = [:]
+        for user in allUsers {
+            if case .guardian(let relatedChildId) = user.userType {
+                guardiansByChildId[relatedChildId, default: []].append(user)
+            }
+        }
+        
+        return Dictionary(grouping: entranceUsers) { $0.classGroupId }
+            .map { classGroupId, users in
+                BorrowerListSection(
+                    id: classGroupId,
+                    title: classGroupModel.findClassGroupById(classGroupId)?.name ?? "未分類",
+                    rows:
+                        users
+                        .sorted { $0.name < $1.name }
+                        .map { user in
+                            // 家庭の全員（本人＋紐づく保護者）が借用中なら空き枠なし
+                            let familyMembers = [user] + (guardiansByChildId[user.id] ?? [])
+                            return BorrowerRowDisplay(
+                                id: user.id,
+                                name: user.name,
+                                isGuardian: user.userType.category == .guardian,
+                                isOverdue: false,
+                                hasNoOpenSlot: familyMembers.allSatisfy {
+                                    borrowedUserIds.contains($0.id)
+                                }
+                            )
+                        }
+                )
+            }
+            .sorted { $0.title < $1.title }
+    }
+    
+    /// 貸出中の図書の説明文（「いつ戻るか」の目安を日付だけで知らせる）
+    ///
+    /// 誰が借りているかは表示しない（プライバシー配慮・IA_REVIEW 追記13）
+    private func lentBookDescription(for book: Book) -> String {
+        if let loan = loanModel.getCurrentLoan(bookId: book.id) {
+            "\(loan.dueDateText)ごろ返却予定です"
+        } else {
+            "返却されると貸出できるようになります"
+        }
+    }
+    
+    // MARK: - Actions
+    
+    /// 枠確認画面での返却の取り消し（Undoカードの「元に戻す」）
+    ///
+    /// 取り消したらその場に留まり、枠に本が戻るのを見せる
+    private func handleUndoReturn() {
+        guard let loanId = undoFeedback.targetId else { return }
+        do {
+            try loanModel.undoReturn(loanId: loanId)
+        } catch {
+            alertState = .error("返却の取り消しに失敗しました", message: error.localizedDescription)
+        }
+    }
+    
+    /// 貸出の実行（枠選択のタップで確定・✓カードで完了を伝える）
+    private func handleLend(book: Book, userId: UUID) {
+        do {
+            _ = try loanModel.lendBook(bookId: book.id, userId: userId)
+            let name = userModel.findUserById(userId)?.name ?? ""
+            successFeedback.show("\(name)さんに『\(book.title)』を貸出しました")
+            isPopPendingAfterLend = true
+            idleTicket += 1
+        } catch {
+            alertState = .error("貸出に失敗しました", message: error.localizedDescription)
+        }
+    }
+}
+
+/// 枠確認画面への遷移値（選んだ図書＋家庭を特定する利用者ID）
+private struct BorrowConfirmRoute: Hashable {
+    let book: Book
+    let userId: UUID
+}
+
+#Preview {
+    let mockFactory = MockRepositoryFactory()
+    let bookModel = BookModel(repository: mockFactory.bookRepository)
+    let userModel = UserModel(repository: mockFactory.userRepository)
+    let classGroupModel = ClassGroupModel(repository: mockFactory.classGroupRepository)
+    let loanModel = LoanModel(
+        repository: mockFactory.loanRepository,
+        bookRepository: mockFactory.bookRepository,
+        userRepository: mockFactory.userRepository,
+        loanSettingsRepository: mockFactory.loanSettingsRepository
+    )
+    
+    // 組1つ・園児2人（うち1人に保護者を紐付け）・図書1冊（貸出可能）をセットアップ
+    let momo = ClassGroup(name: "もも組", ageGroup: AgeGroup.age(4), year: 2026)
+    try! mockFactory.classGroupRepository.save(momo)
+    
+    let sakura = try! userModel.registerUser(User(name: "いとう さくら", classGroupId: momo.id))
+    _ = try! userModel.registerUser(
+        User(
+            name: "伊藤 由美子", classGroupId: momo.id,
+            userType: .guardian(relatedChildId: sakura.id)))
+    _ = try! userModel.registerUser(User(name: "あおき はると", classGroupId: momo.id))
+    
+    let guriToGura = try! bookModel.registerBook(Book(title: "ぐりとぐら", author: "中川李枝子"))
+    
+    return BorrowSheetContainerView(
+        context: BorrowSheetContext(book: guriToGura, isAlreadyLent: false),
+        onClose: {},
+        onLendCompleted: {}
+    )
+    .environment(userModel)
+    .environment(loanModel)
+    .environment(classGroupModel)
+}

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/ClassGroup/ClassGroupListContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/ClassGroup/ClassGroupListContainerView.swift
@@ -73,9 +73,6 @@ struct ClassGroupListContainerView: View {
         } message: {
             Text(alertState.message)
         }
-        .onAppear {
-            classGroupModel.refreshClassGroups()
-        }
     }
     
     // MARK: - Actions

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/ClassGroupSelectionContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/ClassGroupSelectionContainerView.swift
@@ -23,18 +23,11 @@ struct ClassGroupSelectionContainerView: View {
         } message: {
             Text(alertState.message)
         }
-        .onAppear {
-            refreshClassGroups()
-        }
     }
     
     private func handleSelect(_ classGroup: ClassGroup) {
         onSelect(classGroup)
         dismiss()
-    }
-    
-    private func refreshClassGroups() {
-        classGroupModel.refreshClassGroups()
     }
 }
 

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Family/FamilyLoanSlotsContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Family/FamilyLoanSlotsContainerView.swift
@@ -24,14 +24,19 @@ struct FamilyLoanSlotsContainerView: View {
     @Environment(LoanModel.self) private var loanModel
     @Environment(BookModel.self) private var bookModel
     
-    /// アラート状態管理（エラー表示用）
-    @Binding var alertState: AlertState
     /// 返却のUndoフィードバック状態管理
     ///
     /// 文脈enumに含めない：返却タブの返却Undoだけでなく、貸出フロー内の
     /// 「枠の入れ替え（先に返し忘れた本をその場で返却して空けるUndo）」でも
-    /// 使われる、両モード共通の状態のため（`handleReturn`参照）
+    /// 使われる、両モード共通の状態のため（`handleReturn`参照）。
+    /// alertStateと違い@Binding：返却完了で子ごとpopされた後もUndoカードは
+    /// 親レベルで生き残る必要があり、子より長寿命の状態は親所有が正しいため
     @Binding var undoFeedback: UndoFeedback
+    
+    /// アラート状態管理（エラー表示用）
+    ///
+    /// エラーアラートは子の生存中にしか出ないため、子が自前で持ち自分で`.alert`を付ける
+    @State private var alertState = AlertState()
     
     /// 家庭を特定する利用者ID（園児・保護者どちらでも可）
     let userId: UUID
@@ -45,6 +50,11 @@ struct FamilyLoanSlotsContainerView: View {
             onReturn: handleReturn(_:),
             onBorrow: handleBorrow(_:)
         )
+        .alert(alertState.title, isPresented: $alertState.isPresented) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(alertState.message)
+        }
     }
     
     // MARK: - Computed Properties
@@ -126,7 +136,6 @@ struct FamilyLoanSlotsContainerView: View {
 }
 
 #Preview("返却文脈（実データ相当）") {
-    @Previewable @State var alertState = AlertState()
     @Previewable @State var undoFeedback = UndoFeedback()
     
     let mockFactory = MockRepositoryFactory()
@@ -150,7 +159,6 @@ struct FamilyLoanSlotsContainerView: View {
     
     return ScrollView {
         FamilyLoanSlotsContainerView(
-            alertState: $alertState,
             undoFeedback: $undoFeedback,
             userId: mother.id,  // 保護者のIDから入っても同じ家庭に解決される
             context: .returning(onReturnCompleted: { _ in })

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Return/ReturnListContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Return/ReturnListContainerView.swift
@@ -94,7 +94,6 @@ struct ReturnListContainerView: View {
     private func familyScreen(for userId: UUID) -> some View {
         ScrollView {
             FamilyLoanSlotsContainerView(
-                alertState: $alertState,
                 undoFeedback: $undoFeedback,
                 userId: userId,
                 context: .returning(onReturnCompleted: handleReturnCompleted(hasRemainingLoans:))

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Return/ReturnListContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Return/ReturnListContainerView.swift
@@ -80,9 +80,6 @@ struct ReturnListContainerView: View {
                 popToListAndScrollTop()
             }
         }
-        .onAppear {
-            refreshData()
-        }
         .refreshable {
             refreshData()
         }

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/User/UserListContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/User/UserListContainerView.swift
@@ -107,9 +107,6 @@ struct UserListContainerView: View {
         } message: {
             Text(deleteConfirmationState.message)
         }
-        .onAppear {
-            userModel.refreshUsers()
-        }
         .refreshable {
             userModel.refreshUsers()
         }


### PR DESCRIPTION
## 概要

⚠️ **運用ミスの復旧PRです。** #198・#200・#201はチェーン式（base=前段のfeatureブランチ）で作られましたが、前段がmainにマージされた後にbaseをmainへ付け替えないままマージしてしまい、**3件の変更内容が実際にはmainへ反映されていませんでした**（PR自体は「Merged」表示になるため見た目上は分かりにくい状態でした）。

このPRで、以下の未反映だった変更をmainへ統合します:

- alertStateの自前化（[#195](https://github.com/takuyaaaaaaahaaaaaa/PictureBookLendingApp/issues/195) / 旧#198）: `FamilyLoanSlotsContainerView`が親の`@Binding alertState`をやめ、自分の`@State`で持つように変更
- refresh呼び出しの一括化（[#194](https://github.com/takuyaaaaaaahaaaaaa/PictureBookLendingApp/issues/194) / 旧#200）: `ContentView`でタブ切替・scenePhase復帰時に全Modelを一括リフレッシュ
- 貸出シートの分割（[#193](https://github.com/takuyaaaaaaahaaaaaa/PictureBookLendingApp/issues/193) / 旧#201）: `BorrowListContainerView`からシート内フローを`BorrowSheetContainerView`に分離

`#197`（BookSections値型化）と重複するコミットは除外済みです（#197はすでにmainへ正しく反映済み）。

## テスト

- swift format lint: 違反0
- 全テスト（iPad Pro 11-inch (M5) シミュレータ）: TEST SUCCEEDED

## レビューポイント

貸出シート分割はUXが本質の変更のため、マージ前に実機での最終確認を推奨します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)