### PR TITLE
fix: 貸出中案内シートをスワイプで閉じられるようにする

### DIFF
--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Borrow/BorrowSheetContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Borrow/BorrowSheetContainerView.swift
@@ -82,8 +82,10 @@ struct BorrowSheetContainerView: View {
             }
         }
         // 誤スワイプで貸出タスクが途中で消えないようにする（閉じるのは✕ボタンから。
-        // 絵本管理の貸出フォームと同じ作法）
-        .interactiveDismissDisabled()
+        // 絵本管理の貸出フォームと同じ作法）。
+        // ただし「貸出中です」の案内だけの画面は入力途中のタスクがなく、
+        // すぐ閉じてよい画面なのでスワイプでの閉じるを許可する
+        .interactiveDismissDisabled(!context.isAlreadyLent)
     }
     
     // MARK: - Private Views


### PR DESCRIPTION
## Summary
- 図書一覧から貸出中の本をタップした際に出る「この図書は貸出中です」案内シートを、スワイプでも閉じられるようにした
- 通常の貸出フロー（利用者選択→枠確認）はこれまで通り誤スワイプ防止のため`interactiveDismissDisabled`のまま

## Why
案内だけの画面は入力途中のタスクがなく、すぐ閉じてよい画面のため。

## Test plan
- [ ] シミュレータ/実機で貸出中の本をタップし、下スワイプでシートが閉じることを確認
- [ ] 通常の貸出フロー中は誤スワイプで閉じないことを確認
- [x] `xcodebuild -scheme PictureBookLendingAdmin build` 成功確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)