### PR TITLE
docs: アプリ名を「えほん台帳」としてCLAUDE.mdに記載

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,8 @@
-# PictureBookLendingApp
+# PictureBookLendingApp（アプリ名：えほん台帳）
 
 ## 概要
 
-**PictureBookLendingApp** は、保育園・幼稚園向けに *絵本の貸出・返却業務を iPad だけで完結* させる貸出管理システムです。Web サーバやクラウドを利用しない完全オフライン運用を前提とします。
+**えほん台帳**（リポジトリ名: PictureBookLendingApp）は、保育園・幼稚園向けに *絵本の貸出・返却業務を iPad だけで完結* させる貸出管理システムです。Web サーバやクラウドを利用しない完全オフライン運用を前提とします。
 
 **画面構成**: `docs/SCREEN_DESIGN.md` を参照
 


### PR DESCRIPTION
## Summary
- アプリ名を「えほん台帳」に決定し、CLAUDE.mdのタイトル・概要に記載
- Xcodeプロジェクトの `CFBundleDisplayName` は既に「えほん台帳」で設定済みのため変更なし
- READMEはリポジトリに存在しないため対象外

ドキュメントのみの変更です。

---
_Generated by [Claude Code](https://claude.ai/code/session_01CoLe6MGBbF5cno5Uohret7)_