### PR TITLE
feat: 貸出の節目に紙吹雪のお祝いフィードバックを追加

### DIFF
--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Presentation/LoanMilestone+Formatter.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Presentation/LoanMilestone+Formatter.swift
@@ -1,0 +1,27 @@
+import PictureBookLendingDomain
+
+extension LoanMilestone {
+    /// お祝いカードのタイトル（例：「10回よんだよ！」）
+    ///
+    /// 主役は園児。お迎えの場で本人・保護者・先生が一緒に見るため、
+    /// 数字が主役になる短い言葉にする
+    var celebrationTitle: String {
+        switch self {
+        case .repeatedBook(let count): "\(count)回よんだよ！"
+        case .consecutiveWeeks(let count): "\(count)週連続！"
+        case .distinctBooks(let count): "\(count)冊よんだよ！"
+        }
+    }
+
+    /// お祝いカードのメッセージ（利用者名・図書タイトルを添える）
+    func celebrationMessage(userName: String, bookTitle: String) -> String {
+        switch self {
+        case .repeatedBook(let count):
+            "\(userName)さん、『\(bookTitle)』を\(count)回かりました！だいすきな1冊だね"
+        case .consecutiveWeeks(let count):
+            "\(userName)さん、\(count)週つづけてかりています！すごい！"
+        case .distinctBooks(let count):
+            "\(userName)さん、これで\(count)冊目の図書です！おめでとう！"
+        }
+    }
+}

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Presentation/LoanMilestone+Formatter.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Presentation/LoanMilestone+Formatter.swift
@@ -12,7 +12,7 @@ extension LoanMilestone {
         case .distinctBooks(let count): "\(count)冊よんだよ！"
         }
     }
-
+    
     /// お祝いカードのメッセージ（利用者名・図書タイトルを添える）
     func celebrationMessage(userName: String, bookTitle: String) -> String {
         switch self {

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Borrow/BorrowSheetContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Borrow/BorrowSheetContainerView.swift
@@ -29,6 +29,8 @@ struct BorrowSheetContainerView: View {
     @State private var selectedClassGroupId: UUID?
     @State private var alertState = AlertState()
     @State private var successFeedback = SuccessFeedback()
+    /// 貸出が節目（同じ図書の繰り返し・連続週・種類数）に達したときの紙吹雪お祝いカード状態
+    @State private var celebrationFeedback = CelebrationFeedback()
     /// 貸出後、✓カードの表示が終わったらシートを閉じる（図書一覧へ戻す）ための予約フラグ
     @State private var isPopPendingAfterLend = false
     /// 選択画面の無操作タイマーのトークン（操作のたびに更新して待ち時間を延長する）
@@ -70,6 +72,9 @@ struct BorrowSheetContainerView: View {
             Text(alertState.message)
         }
         .successFeedback($successFeedback, displayDuration: Self.lendFeedbackDuration)
+        // 貸出が節目に達したときは✓カードの代わりに紙吹雪でお祝いする
+        // （自動終了・タップスキップ付き。DESIGN_PRINCIPLES「節目のお祝い」）
+        .celebrationFeedback($celebrationFeedback)
         // 枠確認画面での返却（本の入れ替え）に対するUndoカード。
         // 取り消してもその場に留まり、枠に本が戻るのを見せる
         .undoFeedback($undoFeedback, onUndo: handleUndoReturn)
@@ -78,6 +83,13 @@ struct BorrowSheetContainerView: View {
             if wasPresented && !isPresented && isPopPendingAfterLend {
                 isPopPendingAfterLend = false
                 // 貸出完了→次の貸出のために親へ通知（絞り込み解除・先頭スクロールは親側の状態）
+                onLendCompleted()
+            }
+        }
+        .onChange(of: celebrationFeedback.isPresented) { wasPresented, isPresented in
+            // お祝いが終わったら（自動終了・タップスキップとも）✓カードと同じ作法でシートを閉じる
+            if wasPresented && !isPresented && isPopPendingAfterLend {
+                isPopPendingAfterLend = false
                 onLendCompleted()
             }
         }
@@ -268,12 +280,21 @@ struct BorrowSheetContainerView: View {
         }
     }
     
-    /// 貸出の実行（枠選択のタップで確定・✓カードで完了を伝える）
+    /// 貸出の実行（枠選択のタップで確定・✓カードまたは節目のお祝いで完了を伝える）
     private func handleLend(book: Book, userId: UUID) {
         do {
-            _ = try loanModel.lendBook(bookId: book.id, userId: userId)
+            let loan = try loanModel.lendBook(bookId: book.id, userId: userId)
             let name = userModel.findUserById(userId)?.name ?? ""
-            successFeedback.show("\(name)さんに『\(book.title)』を貸出しました")
+            // 節目に達していたら✓カードの代わりに紙吹雪のお祝いを表示する。
+            // 同時に複数の節目に達した場合は、優先度の最も高い1つだけを祝う
+            if let milestone = loanModel.achievedMilestones(for: loan).first {
+                celebrationFeedback.show(
+                    title: milestone.celebrationTitle,
+                    message: milestone.celebrationMessage(userName: name, bookTitle: book.title)
+                )
+            } else {
+                successFeedback.show("\(name)さんに『\(book.title)』を貸出しました")
+            }
             isPopPendingAfterLend = true
             idleTicket += 1
         } catch {

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Debug/UICatalogContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Debug/UICatalogContainerView.swift
@@ -1,4 +1,5 @@
 #if DEBUG
+    import PictureBookLendingDomain
     import PictureBookLendingUI
     import SwiftUI
     
@@ -8,12 +9,18 @@
     /// Phase 2のコンポーネントを実機で確認するための足場で、
     /// issue #40（UIカタログ）の最小実装を兼ねます。
     struct UICatalogContainerView: View {
+        @State private var celebrationFeedback = CelebrationFeedback()
+        
         private let childId = UUID()
         private let guardianId = UUID()
         
         var body: some View {
             ScrollView {
                 VStack(alignment: .leading, spacing: 32) {
+                    catalogSection("節目のお祝い：紙吹雪＋カード（タップでスキップ・3.5秒で自動終了）") {
+                        celebrationDemo
+                    }
+                    
                     catalogSection("家庭の枠：返却文脈（両方貸出中・1件延滞）") {
                         FamilyLoanSlotsView(
                             slots: [
@@ -89,6 +96,16 @@
             }
             .background(.background)
             .navigationTitle("UIカタログ（開発用）")
+            .celebrationFeedback($celebrationFeedback)
+        }
+        
+        /// 節目のお祝いフィードバックの発火ボタン（節目の種類ごとに文言も確認できる）
+        private var celebrationDemo: some View {
+            HStack(spacing: 12) {
+                celebrationButton("同じ図書 5回", milestone: .repeatedBook(count: 5))
+                celebrationButton("4週連続", milestone: .consecutiveWeeks(count: 4))
+                celebrationButton("10冊目", milestone: .distinctBooks(count: 10))
+            }
         }
         
         /// 借用者一覧（組インデックスのスクロール確認用・ダミー5組×6人）
@@ -120,6 +137,18 @@
                     .foregroundStyle(.secondary)
                 content()
             }
+        }
+        
+        /// 節目のお祝いを発火するボタン（実際の貸出時と同じ文言生成を通す）
+        private func celebrationButton(_ label: String, milestone: LoanMilestone) -> some View {
+            Button(label) {
+                celebrationFeedback.show(
+                    title: milestone.celebrationTitle,
+                    message: milestone.celebrationMessage(
+                        userName: "いとう さくら", bookTitle: "ぐりとぐら")
+                )
+            }
+            .buttonStyle(.bordered)
         }
     }
     

--- a/PictureBookLendingAdminApp/PictureBookLendingDomain/Sources/Domain/LoanMilestone.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingDomain/Sources/Domain/LoanMilestone.swift
@@ -1,0 +1,20 @@
+/// 貸出の節目（お祝いの対象となる記念の回数）
+///
+/// 貸出が記念すべき回数に達したことを表します。
+/// どの回数を節目とするかの判定は `LoanMilestoneEvaluator` が行います。
+public enum LoanMilestone: Equatable, Hashable, Sendable, Codable {
+    /// 同じ図書を繰り返し借りた節目
+    ///
+    /// - Parameter count: その図書の通算貸出回数（例：5回目・10回目）
+    case repeatedBook(count: Int)
+
+    /// 連続した週で借り続けた節目
+    ///
+    /// - Parameter count: 連続で借りた週数（例：4週連続）
+    case consecutiveWeeks(count: Int)
+
+    /// いろいろな図書を借りた節目
+    ///
+    /// - Parameter count: これまでに借りた図書の種類数（例：10冊目）
+    case distinctBooks(count: Int)
+}

--- a/PictureBookLendingAdminApp/PictureBookLendingDomain/Sources/Domain/LoanMilestone.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingDomain/Sources/Domain/LoanMilestone.swift
@@ -7,12 +7,12 @@ public enum LoanMilestone: Equatable, Hashable, Sendable, Codable {
     ///
     /// - Parameter count: その図書の通算貸出回数（例：5回目・10回目）
     case repeatedBook(count: Int)
-
+    
     /// 連続した週で借り続けた節目
     ///
     /// - Parameter count: 連続で借りた週数（例：4週連続）
     case consecutiveWeeks(count: Int)
-
+    
     /// いろいろな図書を借りた節目
     ///
     /// - Parameter count: これまでに借りた図書の種類数（例：10冊目）

--- a/PictureBookLendingAdminApp/PictureBookLendingDomain/Sources/Services/LoanMilestoneEvaluator.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingDomain/Sources/Services/LoanMilestoneEvaluator.swift
@@ -1,0 +1,95 @@
+import Foundation
+
+/// 貸出の節目判定サービス
+///
+/// 新しい貸出が「お祝いに値する節目」に達したかを、同じ利用者の過去の貸出記録から判定します。
+/// 判定は純粋な計算のみで、永続化や表示には関与しません。
+public struct LoanMilestoneEvaluator: Sendable {
+
+    /// 節目と判定する間隔
+    private enum Interval {
+        /// 同じ図書の貸出回数の節目間隔（5回・10回・15回…）
+        static let repeatedBook = 5
+        /// 連続週数の節目間隔（4週・8週・12週…）
+        static let consecutiveWeeks = 4
+        /// 図書の種類数の節目間隔（10冊・20冊・30冊…）
+        static let distinctBooks = 10
+    }
+
+    /// 週の区切りの計算に使うカレンダー
+    private let calendar: Calendar
+
+    public init(calendar: Calendar = .current) {
+        self.calendar = calendar
+    }
+
+    /// 新しい貸出が節目に達したかを判定する
+    ///
+    /// - Parameters:
+    ///   - newLoan: いま作成された貸出記録
+    ///   - previousLoans: 同じ利用者の過去の貸出記録（`newLoan` を含まない）
+    /// - Returns: 達した節目のリスト（お祝いの優先度が高い順）。達していなければ空
+    public func evaluate(newLoan: Loan, previousLoans: [Loan]) -> [LoanMilestone] {
+        [
+            repeatedBookMilestone(newLoan: newLoan, previousLoans: previousLoans),
+            consecutiveWeeksMilestone(newLoan: newLoan, previousLoans: previousLoans),
+            distinctBooksMilestone(newLoan: newLoan, previousLoans: previousLoans),
+        ]
+        .compactMap { $0 }
+    }
+
+    /// 同じ図書の繰り返し貸出の節目判定
+    private func repeatedBookMilestone(newLoan: Loan, previousLoans: [Loan]) -> LoanMilestone? {
+        let count = previousLoans.count(where: { $0.bookId == newLoan.bookId }) + 1
+        guard count >= Interval.repeatedBook, count.isMultiple(of: Interval.repeatedBook) else {
+            return nil
+        }
+        return .repeatedBook(count: count)
+    }
+
+    /// 連続週の貸出の節目判定
+    ///
+    /// `newLoan` の週から過去へ、貸出のある週が途切れず何週続いているかを数えます。
+    /// 同じ週にすでに貸出があった場合は連続週数が増えていないため、節目を再判定しません。
+    private func consecutiveWeeksMilestone(newLoan: Loan, previousLoans: [Loan]) -> LoanMilestone?
+    {
+        guard let newWeek = weekStart(of: newLoan.loanDate) else { return nil }
+
+        let previousWeeks = Set(previousLoans.compactMap { weekStart(of: $0.loanDate) })
+        guard !previousWeeks.contains(newWeek) else { return nil }
+
+        var streak = 1
+        var week = newWeek
+        while let previousWeek = calendar.date(byAdding: .weekOfYear, value: -1, to: week),
+            let normalized = weekStart(of: previousWeek),
+            previousWeeks.contains(normalized)
+        {
+            streak += 1
+            week = normalized
+        }
+
+        guard streak >= Interval.consecutiveWeeks,
+            streak.isMultiple(of: Interval.consecutiveWeeks)
+        else { return nil }
+        return .consecutiveWeeks(count: streak)
+    }
+
+    /// 図書の種類数の節目判定
+    ///
+    /// 初めて借りる図書のときだけ種類数が増えるため、そのときのみ判定します。
+    private func distinctBooksMilestone(newLoan: Loan, previousLoans: [Loan]) -> LoanMilestone? {
+        let previousBookIds = Set(previousLoans.map(\.bookId))
+        guard !previousBookIds.contains(newLoan.bookId) else { return nil }
+
+        let count = previousBookIds.count + 1
+        guard count >= Interval.distinctBooks, count.isMultiple(of: Interval.distinctBooks) else {
+            return nil
+        }
+        return .distinctBooks(count: count)
+    }
+
+    /// 日付が属する週の開始日時
+    private func weekStart(of date: Date) -> Date? {
+        calendar.dateInterval(of: .weekOfYear, for: date)?.start
+    }
+}

--- a/PictureBookLendingAdminApp/PictureBookLendingDomain/Sources/Services/LoanMilestoneEvaluator.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingDomain/Sources/Services/LoanMilestoneEvaluator.swift
@@ -6,14 +6,18 @@ import Foundation
 /// 判定は純粋な計算のみで、永続化や表示には関与しません。
 public struct LoanMilestoneEvaluator: Sendable {
     
-    /// 節目と判定する間隔
-    private enum Interval {
-        /// 同じ図書の貸出回数の節目間隔（5回・10回・15回…）
-        static let repeatedBook = 5
-        /// 連続週数の節目間隔（4週・8週・12週…）
-        static let consecutiveWeeks = 4
-        /// 図書の種類数の節目間隔（10冊・20冊・30冊…）
-        static let distinctBooks = 10
+    /// 節目と判定する回数（階段式）
+    ///
+    /// 毎週借りる園児だと等間隔（4週ごと等）ではお祝いが月1回以上発火して
+    /// 特別感が薄れるため、上の節目ほど間隔が広がる階段式にしている。
+    /// 熱心に借りる園児でも年5〜7回程度に収まる想定
+    private enum CelebrationCounts {
+        /// 同じ図書の貸出回数の節目（それ以降は祝わない）
+        static let repeatedBook: Set<Int> = [5, 10]
+        /// 連続週数の節目（約1ヶ月・学期・半年・通年の区切り）
+        static let consecutiveWeeks: Set<Int> = [4, 12, 24, 36]
+        /// 図書の種類数の節目
+        static let distinctBooks: Set<Int> = [10, 30, 50]
     }
     
     /// 週の区切りの計算に使うカレンダー
@@ -41,9 +45,7 @@ public struct LoanMilestoneEvaluator: Sendable {
     /// 同じ図書の繰り返し貸出の節目判定
     private func repeatedBookMilestone(newLoan: Loan, previousLoans: [Loan]) -> LoanMilestone? {
         let count = previousLoans.count(where: { $0.bookId == newLoan.bookId }) + 1
-        guard count >= Interval.repeatedBook, count.isMultiple(of: Interval.repeatedBook) else {
-            return nil
-        }
+        guard CelebrationCounts.repeatedBook.contains(count) else { return nil }
         return .repeatedBook(count: count)
     }
     
@@ -67,9 +69,7 @@ public struct LoanMilestoneEvaluator: Sendable {
             week = normalized
         }
         
-        guard streak >= Interval.consecutiveWeeks,
-            streak.isMultiple(of: Interval.consecutiveWeeks)
-        else { return nil }
+        guard CelebrationCounts.consecutiveWeeks.contains(streak) else { return nil }
         return .consecutiveWeeks(count: streak)
     }
     
@@ -81,9 +81,7 @@ public struct LoanMilestoneEvaluator: Sendable {
         guard !previousBookIds.contains(newLoan.bookId) else { return nil }
         
         let count = previousBookIds.count + 1
-        guard count >= Interval.distinctBooks, count.isMultiple(of: Interval.distinctBooks) else {
-            return nil
-        }
+        guard CelebrationCounts.distinctBooks.contains(count) else { return nil }
         return .distinctBooks(count: count)
     }
     

--- a/PictureBookLendingAdminApp/PictureBookLendingDomain/Sources/Services/LoanMilestoneEvaluator.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingDomain/Sources/Services/LoanMilestoneEvaluator.swift
@@ -5,7 +5,7 @@ import Foundation
 /// 新しい貸出が「お祝いに値する節目」に達したかを、同じ利用者の過去の貸出記録から判定します。
 /// 判定は純粋な計算のみで、永続化や表示には関与しません。
 public struct LoanMilestoneEvaluator: Sendable {
-
+    
     /// 節目と判定する間隔
     private enum Interval {
         /// 同じ図書の貸出回数の節目間隔（5回・10回・15回…）
@@ -15,14 +15,14 @@ public struct LoanMilestoneEvaluator: Sendable {
         /// 図書の種類数の節目間隔（10冊・20冊・30冊…）
         static let distinctBooks = 10
     }
-
+    
     /// 週の区切りの計算に使うカレンダー
     private let calendar: Calendar
-
+    
     public init(calendar: Calendar = .current) {
         self.calendar = calendar
     }
-
+    
     /// 新しい貸出が節目に達したかを判定する
     ///
     /// - Parameters:
@@ -37,7 +37,7 @@ public struct LoanMilestoneEvaluator: Sendable {
         ]
         .compactMap { $0 }
     }
-
+    
     /// 同じ図書の繰り返し貸出の節目判定
     private func repeatedBookMilestone(newLoan: Loan, previousLoans: [Loan]) -> LoanMilestone? {
         let count = previousLoans.count(where: { $0.bookId == newLoan.bookId }) + 1
@@ -46,18 +46,17 @@ public struct LoanMilestoneEvaluator: Sendable {
         }
         return .repeatedBook(count: count)
     }
-
+    
     /// 連続週の貸出の節目判定
     ///
     /// `newLoan` の週から過去へ、貸出のある週が途切れず何週続いているかを数えます。
     /// 同じ週にすでに貸出があった場合は連続週数が増えていないため、節目を再判定しません。
-    private func consecutiveWeeksMilestone(newLoan: Loan, previousLoans: [Loan]) -> LoanMilestone?
-    {
+    private func consecutiveWeeksMilestone(newLoan: Loan, previousLoans: [Loan]) -> LoanMilestone? {
         guard let newWeek = weekStart(of: newLoan.loanDate) else { return nil }
-
+        
         let previousWeeks = Set(previousLoans.compactMap { weekStart(of: $0.loanDate) })
         guard !previousWeeks.contains(newWeek) else { return nil }
-
+        
         var streak = 1
         var week = newWeek
         while let previousWeek = calendar.date(byAdding: .weekOfYear, value: -1, to: week),
@@ -67,27 +66,27 @@ public struct LoanMilestoneEvaluator: Sendable {
             streak += 1
             week = normalized
         }
-
+        
         guard streak >= Interval.consecutiveWeeks,
             streak.isMultiple(of: Interval.consecutiveWeeks)
         else { return nil }
         return .consecutiveWeeks(count: streak)
     }
-
+    
     /// 図書の種類数の節目判定
     ///
     /// 初めて借りる図書のときだけ種類数が増えるため、そのときのみ判定します。
     private func distinctBooksMilestone(newLoan: Loan, previousLoans: [Loan]) -> LoanMilestone? {
         let previousBookIds = Set(previousLoans.map(\.bookId))
         guard !previousBookIds.contains(newLoan.bookId) else { return nil }
-
+        
         let count = previousBookIds.count + 1
         guard count >= Interval.distinctBooks, count.isMultiple(of: Interval.distinctBooks) else {
             return nil
         }
         return .distinctBooks(count: count)
     }
-
+    
     /// 日付が属する週の開始日時
     private func weekStart(of date: Date) -> Date? {
         calendar.dateInterval(of: .weekOfYear, for: date)?.start

--- a/PictureBookLendingAdminApp/PictureBookLendingDomain/Tests/Services/LoanMilestoneEvaluatorTests.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingDomain/Tests/Services/LoanMilestoneEvaluatorTests.swift
@@ -1,0 +1,185 @@
+import Foundation
+import Testing
+
+@testable import PictureBookLendingDomain
+
+/// LoanMilestoneEvaluatorテストケース
+///
+/// 貸出の節目（同じ図書の繰り返し・連続週・図書の種類数）の判定をテストします。
+@Suite("LoanMilestoneEvaluator Tests")
+struct LoanMilestoneEvaluatorTests {
+
+    /// テストの基準日（2026-01-15 木曜日 12:00 UTC）
+    private static let baseDate = Date(timeIntervalSince1970: 1_768_478_400)
+
+    private let calendar: Calendar = {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "UTC")!
+        return calendar
+    }()
+
+    private let user = User(name: "山田太郎", classGroupId: UUID())
+
+    private var evaluator: LoanMilestoneEvaluator {
+        LoanMilestoneEvaluator(calendar: calendar)
+    }
+
+    /// 基準日から週数をずらした日付で貸出記録を作る
+    private func makeLoan(bookId: UUID, weeksAgo: Int = 0, daysOffset: Int = 0) -> Loan {
+        var loanDate = calendar.date(
+            byAdding: .weekOfYear, value: -weeksAgo, to: Self.baseDate)!
+        loanDate = calendar.date(byAdding: .day, value: daysOffset, to: loanDate)!
+        let dueDate = calendar.date(byAdding: .day, value: 14, to: loanDate)!
+        return Loan(bookId: bookId, user: user, loanDate: loanDate, dueDate: dueDate)
+    }
+
+    // MARK: - 節目なし
+
+    @Test("初回の貸出は節目に達しない")
+    func firstLoanHasNoMilestone() {
+        let bookId = UUID()
+        let newLoan = makeLoan(bookId: bookId)
+
+        let milestones = evaluator.evaluate(newLoan: newLoan, previousLoans: [])
+
+        #expect(milestones.isEmpty)
+    }
+
+    // MARK: - 同じ図書の繰り返し
+
+    @Test("同じ図書の5回目の貸出で節目に達する")
+    func fifthLoanOfSameBookReachesMilestone() {
+        let bookId = UUID()
+        let previousLoans = (1...4).map { makeLoan(bookId: bookId, weeksAgo: 0, daysOffset: -$0) }
+        let newLoan = makeLoan(bookId: bookId)
+
+        let milestones = evaluator.evaluate(newLoan: newLoan, previousLoans: previousLoans)
+
+        #expect(milestones == [.repeatedBook(count: 5)])
+    }
+
+    @Test("同じ図書の4回目の貸出は節目に達しない")
+    func fourthLoanOfSameBookHasNoMilestone() {
+        let bookId = UUID()
+        let previousLoans = (1...3).map { makeLoan(bookId: bookId, weeksAgo: 0, daysOffset: -$0) }
+        let newLoan = makeLoan(bookId: bookId)
+
+        let milestones = evaluator.evaluate(newLoan: newLoan, previousLoans: previousLoans)
+
+        #expect(milestones.isEmpty)
+    }
+
+    @Test("同じ図書の10回目の貸出で節目に達する")
+    func tenthLoanOfSameBookReachesMilestone() {
+        let bookId = UUID()
+        let previousLoans = (1...9).map { makeLoan(bookId: bookId, weeksAgo: 0, daysOffset: -$0) }
+        let newLoan = makeLoan(bookId: bookId)
+
+        let milestones = evaluator.evaluate(newLoan: newLoan, previousLoans: previousLoans)
+
+        #expect(milestones == [.repeatedBook(count: 10)])
+    }
+
+    // MARK: - 図書の種類数
+
+    @Test("10種類目の図書の貸出で節目に達する")
+    func tenthDistinctBookReachesMilestone() {
+        let previousLoans = (1...9).map { _ in makeLoan(bookId: UUID(), daysOffset: -1) }
+        let newLoan = makeLoan(bookId: UUID())
+
+        let milestones = evaluator.evaluate(newLoan: newLoan, previousLoans: previousLoans)
+
+        #expect(milestones == [.distinctBooks(count: 10)])
+    }
+
+    @Test("借りたことのある図書では種類数の節目に達しない")
+    func alreadyBorrowedBookDoesNotIncreaseDistinctCount() {
+        let knownBookId = UUID()
+        var previousLoans = (1...8).map { _ in makeLoan(bookId: UUID(), daysOffset: -2) }
+        previousLoans.append(makeLoan(bookId: knownBookId, daysOffset: -1))
+        // 種類数は9のまま（10冊目にはならない）
+        let newLoan = makeLoan(bookId: knownBookId)
+
+        let milestones = evaluator.evaluate(newLoan: newLoan, previousLoans: previousLoans)
+
+        #expect(!milestones.contains(.distinctBooks(count: 10)))
+    }
+
+    @Test("同じ図書を10回借りても種類数の節目には達しない")
+    func repeatedLoansDoNotCountAsDistinctBooks() {
+        let bookId = UUID()
+        let previousLoans = (1...9).map { makeLoan(bookId: bookId, weeksAgo: 0, daysOffset: -$0) }
+        let newLoan = makeLoan(bookId: bookId)
+
+        let milestones = evaluator.evaluate(newLoan: newLoan, previousLoans: previousLoans)
+
+        #expect(milestones == [.repeatedBook(count: 10)])
+    }
+
+    // MARK: - 連続週の貸出
+
+    @Test("4週連続の貸出で節目に達する")
+    func fourConsecutiveWeeksReachesMilestone() {
+        let previousLoans = (1...3).map { makeLoan(bookId: UUID(), weeksAgo: $0) }
+        let newLoan = makeLoan(bookId: UUID(), weeksAgo: 0)
+
+        let milestones = evaluator.evaluate(newLoan: newLoan, previousLoans: previousLoans)
+
+        #expect(milestones == [.consecutiveWeeks(count: 4)])
+    }
+
+    @Test("3週連続の貸出は節目に達しない")
+    func threeConsecutiveWeeksHasNoMilestone() {
+        let previousLoans = (1...2).map { makeLoan(bookId: UUID(), weeksAgo: $0) }
+        let newLoan = makeLoan(bookId: UUID(), weeksAgo: 0)
+
+        let milestones = evaluator.evaluate(newLoan: newLoan, previousLoans: previousLoans)
+
+        #expect(milestones.isEmpty)
+    }
+
+    @Test("週が途切れると連続週数はリセットされる")
+    func gapWeekResetsStreak() {
+        // 4週前・3週前に借りたが、2週前・1週前は借りていない
+        let previousLoans = [
+            makeLoan(bookId: UUID(), weeksAgo: 4),
+            makeLoan(bookId: UUID(), weeksAgo: 3),
+        ]
+        let newLoan = makeLoan(bookId: UUID(), weeksAgo: 0)
+
+        let milestones = evaluator.evaluate(newLoan: newLoan, previousLoans: previousLoans)
+
+        #expect(milestones.isEmpty)
+    }
+
+    @Test("同じ週の2回目の貸出では連続週の節目を再判定しない")
+    func secondLoanInSameWeekDoesNotRetrigger() {
+        // 3週前〜今週まで毎週借りていて、今週はすでに1回借りている
+        let previousLoans = (0...3).map { makeLoan(bookId: UUID(), weeksAgo: $0, daysOffset: -1) }
+        let newLoan = makeLoan(bookId: UUID(), weeksAgo: 0)
+
+        let milestones = evaluator.evaluate(newLoan: newLoan, previousLoans: previousLoans)
+
+        #expect(milestones.isEmpty)
+    }
+
+    // MARK: - 複数の節目
+
+    @Test("複数の節目に同時に達した場合は優先度順に返す")
+    func multipleMilestonesAreOrderedByPriority() {
+        let bookId = UUID()
+        // 同じ図書を3週前・2週前・1週前・1週前の計4回借りていて、今週5回目を借りる
+        // → 同じ図書5回目＋4週連続の両方に達する
+        let previousLoans = [
+            makeLoan(bookId: bookId, weeksAgo: 3),
+            makeLoan(bookId: bookId, weeksAgo: 2),
+            makeLoan(bookId: bookId, weeksAgo: 1),
+            makeLoan(bookId: bookId, weeksAgo: 1, daysOffset: 1),
+        ]
+        let newLoan = makeLoan(bookId: bookId, weeksAgo: 0)
+
+        let milestones = evaluator.evaluate(newLoan: newLoan, previousLoans: previousLoans)
+
+        #expect(milestones == [.repeatedBook(count: 5), .consecutiveWeeks(count: 4)])
+    }
+}

--- a/PictureBookLendingAdminApp/PictureBookLendingDomain/Tests/Services/LoanMilestoneEvaluatorTests.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingDomain/Tests/Services/LoanMilestoneEvaluatorTests.swift
@@ -80,6 +80,17 @@ struct LoanMilestoneEvaluatorTests {
         #expect(milestones == [.repeatedBook(count: 10)])
     }
     
+    @Test("同じ図書の15回目の貸出はもう節目にしない（お祝いの薄まり防止）")
+    func fifteenthLoanOfSameBookHasNoMilestone() {
+        let bookId = UUID()
+        let previousLoans = (1...14).map { makeLoan(bookId: bookId, weeksAgo: 0, daysOffset: -$0) }
+        let newLoan = makeLoan(bookId: bookId)
+        
+        let milestones = evaluator.evaluate(newLoan: newLoan, previousLoans: previousLoans)
+        
+        #expect(milestones.isEmpty)
+    }
+    
     // MARK: - 図書の種類数
     
     @Test("10種類目の図書の貸出で節目に達する")
@@ -103,6 +114,26 @@ struct LoanMilestoneEvaluatorTests {
         let milestones = evaluator.evaluate(newLoan: newLoan, previousLoans: previousLoans)
         
         #expect(!milestones.contains(.distinctBooks(count: 10)))
+    }
+    
+    @Test("20種類目は節目にしない（次の節目は30冊）")
+    func twentiethDistinctBookHasNoMilestone() {
+        let previousLoans = (1...19).map { _ in makeLoan(bookId: UUID(), daysOffset: -1) }
+        let newLoan = makeLoan(bookId: UUID())
+        
+        let milestones = evaluator.evaluate(newLoan: newLoan, previousLoans: previousLoans)
+        
+        #expect(milestones.isEmpty)
+    }
+    
+    @Test("30種類目の図書の貸出で節目に達する")
+    func thirtiethDistinctBookReachesMilestone() {
+        let previousLoans = (1...29).map { _ in makeLoan(bookId: UUID(), daysOffset: -1) }
+        let newLoan = makeLoan(bookId: UUID())
+        
+        let milestones = evaluator.evaluate(newLoan: newLoan, previousLoans: previousLoans)
+        
+        #expect(milestones == [.distinctBooks(count: 30)])
     }
     
     @Test("同じ図書を10回借りても種類数の節目には達しない")
@@ -136,6 +167,26 @@ struct LoanMilestoneEvaluatorTests {
         let milestones = evaluator.evaluate(newLoan: newLoan, previousLoans: previousLoans)
         
         #expect(milestones.isEmpty)
+    }
+    
+    @Test("8週連続は節目にしない（次の節目は12週）")
+    func eightConsecutiveWeeksHasNoMilestone() {
+        let previousLoans = (1...7).map { makeLoan(bookId: UUID(), weeksAgo: $0) }
+        let newLoan = makeLoan(bookId: UUID(), weeksAgo: 0)
+        
+        let milestones = evaluator.evaluate(newLoan: newLoan, previousLoans: previousLoans)
+        
+        #expect(milestones.isEmpty)
+    }
+    
+    @Test("12週連続の貸出で節目に達する")
+    func twelveConsecutiveWeeksReachesMilestone() {
+        let previousLoans = (1...11).map { makeLoan(bookId: UUID(), weeksAgo: $0) }
+        let newLoan = makeLoan(bookId: UUID(), weeksAgo: 0)
+        
+        let milestones = evaluator.evaluate(newLoan: newLoan, previousLoans: previousLoans)
+        
+        #expect(milestones == [.consecutiveWeeks(count: 12)])
     }
     
     @Test("週が途切れると連続週数はリセットされる")

--- a/PictureBookLendingAdminApp/PictureBookLendingDomain/Tests/Services/LoanMilestoneEvaluatorTests.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingDomain/Tests/Services/LoanMilestoneEvaluatorTests.swift
@@ -8,10 +8,10 @@ import Testing
 /// 貸出の節目（同じ図書の繰り返し・連続週・図書の種類数）の判定をテストします。
 @Suite("LoanMilestoneEvaluator Tests")
 struct LoanMilestoneEvaluatorTests {
-
+    
     /// テストの基準日（2026-01-15 木曜日 12:00 UTC）
     private static let baseDate = Date(timeIntervalSince1970: 1_768_478_400)
-
+    
     private let calendar: Calendar = {
         var calendar = Calendar(identifier: .gregorian)
         calendar.timeZone = TimeZone(identifier: "UTC")!
@@ -19,11 +19,11 @@ struct LoanMilestoneEvaluatorTests {
     }()
 
     private let user = User(name: "山田太郎", classGroupId: UUID())
-
+    
     private var evaluator: LoanMilestoneEvaluator {
         LoanMilestoneEvaluator(calendar: calendar)
     }
-
+    
     /// 基準日から週数をずらした日付で貸出記録を作る
     private func makeLoan(bookId: UUID, weeksAgo: Int = 0, daysOffset: Int = 0) -> Loan {
         var loanDate = calendar.date(
@@ -32,66 +32,66 @@ struct LoanMilestoneEvaluatorTests {
         let dueDate = calendar.date(byAdding: .day, value: 14, to: loanDate)!
         return Loan(bookId: bookId, user: user, loanDate: loanDate, dueDate: dueDate)
     }
-
+    
     // MARK: - 節目なし
-
+    
     @Test("初回の貸出は節目に達しない")
     func firstLoanHasNoMilestone() {
         let bookId = UUID()
         let newLoan = makeLoan(bookId: bookId)
-
+        
         let milestones = evaluator.evaluate(newLoan: newLoan, previousLoans: [])
-
+        
         #expect(milestones.isEmpty)
     }
-
+    
     // MARK: - 同じ図書の繰り返し
-
+    
     @Test("同じ図書の5回目の貸出で節目に達する")
     func fifthLoanOfSameBookReachesMilestone() {
         let bookId = UUID()
         let previousLoans = (1...4).map { makeLoan(bookId: bookId, weeksAgo: 0, daysOffset: -$0) }
         let newLoan = makeLoan(bookId: bookId)
-
+        
         let milestones = evaluator.evaluate(newLoan: newLoan, previousLoans: previousLoans)
-
+        
         #expect(milestones == [.repeatedBook(count: 5)])
     }
-
+    
     @Test("同じ図書の4回目の貸出は節目に達しない")
     func fourthLoanOfSameBookHasNoMilestone() {
         let bookId = UUID()
         let previousLoans = (1...3).map { makeLoan(bookId: bookId, weeksAgo: 0, daysOffset: -$0) }
         let newLoan = makeLoan(bookId: bookId)
-
+        
         let milestones = evaluator.evaluate(newLoan: newLoan, previousLoans: previousLoans)
-
+        
         #expect(milestones.isEmpty)
     }
-
+    
     @Test("同じ図書の10回目の貸出で節目に達する")
     func tenthLoanOfSameBookReachesMilestone() {
         let bookId = UUID()
         let previousLoans = (1...9).map { makeLoan(bookId: bookId, weeksAgo: 0, daysOffset: -$0) }
         let newLoan = makeLoan(bookId: bookId)
-
+        
         let milestones = evaluator.evaluate(newLoan: newLoan, previousLoans: previousLoans)
-
+        
         #expect(milestones == [.repeatedBook(count: 10)])
     }
-
+    
     // MARK: - 図書の種類数
-
+    
     @Test("10種類目の図書の貸出で節目に達する")
     func tenthDistinctBookReachesMilestone() {
         let previousLoans = (1...9).map { _ in makeLoan(bookId: UUID(), daysOffset: -1) }
         let newLoan = makeLoan(bookId: UUID())
-
+        
         let milestones = evaluator.evaluate(newLoan: newLoan, previousLoans: previousLoans)
-
+        
         #expect(milestones == [.distinctBooks(count: 10)])
     }
-
+    
     @Test("借りたことのある図書では種類数の節目に達しない")
     func alreadyBorrowedBookDoesNotIncreaseDistinctCount() {
         let knownBookId = UUID()
@@ -99,45 +99,45 @@ struct LoanMilestoneEvaluatorTests {
         previousLoans.append(makeLoan(bookId: knownBookId, daysOffset: -1))
         // 種類数は9のまま（10冊目にはならない）
         let newLoan = makeLoan(bookId: knownBookId)
-
+        
         let milestones = evaluator.evaluate(newLoan: newLoan, previousLoans: previousLoans)
-
+        
         #expect(!milestones.contains(.distinctBooks(count: 10)))
     }
-
+    
     @Test("同じ図書を10回借りても種類数の節目には達しない")
     func repeatedLoansDoNotCountAsDistinctBooks() {
         let bookId = UUID()
         let previousLoans = (1...9).map { makeLoan(bookId: bookId, weeksAgo: 0, daysOffset: -$0) }
         let newLoan = makeLoan(bookId: bookId)
-
+        
         let milestones = evaluator.evaluate(newLoan: newLoan, previousLoans: previousLoans)
-
+        
         #expect(milestones == [.repeatedBook(count: 10)])
     }
-
+    
     // MARK: - 連続週の貸出
-
+    
     @Test("4週連続の貸出で節目に達する")
     func fourConsecutiveWeeksReachesMilestone() {
         let previousLoans = (1...3).map { makeLoan(bookId: UUID(), weeksAgo: $0) }
         let newLoan = makeLoan(bookId: UUID(), weeksAgo: 0)
-
+        
         let milestones = evaluator.evaluate(newLoan: newLoan, previousLoans: previousLoans)
-
+        
         #expect(milestones == [.consecutiveWeeks(count: 4)])
     }
-
+    
     @Test("3週連続の貸出は節目に達しない")
     func threeConsecutiveWeeksHasNoMilestone() {
         let previousLoans = (1...2).map { makeLoan(bookId: UUID(), weeksAgo: $0) }
         let newLoan = makeLoan(bookId: UUID(), weeksAgo: 0)
-
+        
         let milestones = evaluator.evaluate(newLoan: newLoan, previousLoans: previousLoans)
-
+        
         #expect(milestones.isEmpty)
     }
-
+    
     @Test("週が途切れると連続週数はリセットされる")
     func gapWeekResetsStreak() {
         // 4週前・3週前に借りたが、2週前・1週前は借りていない
@@ -146,25 +146,25 @@ struct LoanMilestoneEvaluatorTests {
             makeLoan(bookId: UUID(), weeksAgo: 3),
         ]
         let newLoan = makeLoan(bookId: UUID(), weeksAgo: 0)
-
+        
         let milestones = evaluator.evaluate(newLoan: newLoan, previousLoans: previousLoans)
-
+        
         #expect(milestones.isEmpty)
     }
-
+    
     @Test("同じ週の2回目の貸出では連続週の節目を再判定しない")
     func secondLoanInSameWeekDoesNotRetrigger() {
         // 3週前〜今週まで毎週借りていて、今週はすでに1回借りている
         let previousLoans = (0...3).map { makeLoan(bookId: UUID(), weeksAgo: $0, daysOffset: -1) }
         let newLoan = makeLoan(bookId: UUID(), weeksAgo: 0)
-
+        
         let milestones = evaluator.evaluate(newLoan: newLoan, previousLoans: previousLoans)
-
+        
         #expect(milestones.isEmpty)
     }
-
+    
     // MARK: - 複数の節目
-
+    
     @Test("複数の節目に同時に達した場合は優先度順に返す")
     func multipleMilestonesAreOrderedByPriority() {
         let bookId = UUID()
@@ -177,9 +177,9 @@ struct LoanMilestoneEvaluatorTests {
             makeLoan(bookId: bookId, weeksAgo: 1, daysOffset: 1),
         ]
         let newLoan = makeLoan(bookId: bookId, weeksAgo: 0)
-
+        
         let milestones = evaluator.evaluate(newLoan: newLoan, previousLoans: previousLoans)
-
+        
         #expect(milestones == [.repeatedBook(count: 5), .consecutiveWeeks(count: 4)])
     }
 }

--- a/PictureBookLendingAdminApp/PictureBookLendingModel/Sources/LoanModel.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingModel/Sources/LoanModel.swift
@@ -387,6 +387,18 @@ public class LoanModel {
         }
     }
     
+    /// 貸出が節目（お祝いの対象となる記念の回数）に達したかを判定する
+    ///
+    /// 同じ利用者の過去の貸出履歴と照らし合わせ、達した節目を返します。
+    /// `lendBook(bookId:userId:)` の直後に、その戻り値を渡して呼び出すことを想定しています。
+    ///
+    /// - Parameter loan: 判定対象の貸出情報
+    /// - Returns: 達した節目のリスト（お祝いの優先度が高い順）。達していなければ空
+    public func achievedMilestones(for loan: Loan) -> [LoanMilestone] {
+        let previousLoans = getLoansByUser(userId: loan.user.id).filter { $0.id != loan.id }
+        return LoanMilestoneEvaluator().evaluate(newLoan: loan, previousLoans: previousLoans)
+    }
+
     /// 指定された利用者の現在アクティブな貸出情報を取得する
     ///
     /// - Parameter userId: 取得したい利用者のID

--- a/PictureBookLendingAdminApp/PictureBookLendingModel/Sources/LoanModel.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingModel/Sources/LoanModel.swift
@@ -398,7 +398,7 @@ public class LoanModel {
         let previousLoans = getLoansByUser(userId: loan.user.id).filter { $0.id != loan.id }
         return LoanMilestoneEvaluator().evaluate(newLoan: loan, previousLoans: previousLoans)
     }
-
+    
     /// 指定された利用者の現在アクティブな貸出情報を取得する
     ///
     /// - Parameter userId: 取得したい利用者のID

--- a/PictureBookLendingAdminApp/PictureBookLendingModel/Tests/LoanModelTests.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingModel/Tests/LoanModelTests.swift
@@ -407,4 +407,55 @@ struct LoanModelTests {
         #expect(allLoansBefore.map(\.id) == allLoansAfter.map(\.id))
         #expect(allLoansBefore.map(\.isReturned) == allLoansAfter.map(\.isReturned))
     }
+
+    /// 初回の貸出では節目に達しないことのテスト
+    @Test("初回の貸出は節目に達しないテスト")
+    @MainActor
+    func achievedMilestonesForFirstLoan() throws {
+        let (_, _, _, loanModel, testBook, testUser) = try createLoanModel()
+
+        let loan = try loanModel.lendBook(bookId: testBook.id, userId: testUser.id)
+
+        #expect(loanModel.achievedMilestones(for: loan).isEmpty)
+    }
+
+    /// 同じ図書を5回借りると節目に達することのテスト
+    @Test("同じ図書の5回目の貸出で節目に達するテスト")
+    @MainActor
+    func achievedMilestonesForRepeatedBook() throws {
+        let (_, _, _, loanModel, testBook, testUser) = try createLoanModel()
+
+        // 4回借りて返す
+        for _ in 1...4 {
+            let loan = try loanModel.lendBook(bookId: testBook.id, userId: testUser.id)
+            _ = try loanModel.returnBook(loanId: loan.id)
+        }
+
+        // 5回目の貸出で節目に達する
+        let fifthLoan = try loanModel.lendBook(bookId: testBook.id, userId: testUser.id)
+
+        #expect(loanModel.achievedMilestones(for: fifthLoan) == [.repeatedBook(count: 5)])
+    }
+
+    /// 10種類目の図書を借りると節目に達することのテスト
+    @Test("10種類目の図書の貸出で節目に達するテスト")
+    @MainActor
+    func achievedMilestonesForDistinctBooks() throws {
+        let (mockRepositoryFactory, _, _, loanModel, testBook, testUser) = try createLoanModel()
+
+        // 最初の図書を含めて9種類を借りて返す
+        var loan = try loanModel.lendBook(bookId: testBook.id, userId: testUser.id)
+        _ = try loanModel.returnBook(loanId: loan.id)
+        for index in 2...9 {
+            let book = try mockRepositoryFactory.bookRepository.save(Book(title: "図書\(index)"))
+            loan = try loanModel.lendBook(bookId: book.id, userId: testUser.id)
+            _ = try loanModel.returnBook(loanId: loan.id)
+        }
+
+        // 10種類目の貸出で節目に達する
+        let tenthBook = try mockRepositoryFactory.bookRepository.save(Book(title: "図書10"))
+        let tenthLoan = try loanModel.lendBook(bookId: tenthBook.id, userId: testUser.id)
+
+        #expect(loanModel.achievedMilestones(for: tenthLoan) == [.distinctBooks(count: 10)])
+    }
 }

--- a/PictureBookLendingAdminApp/PictureBookLendingModel/Tests/LoanModelTests.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingModel/Tests/LoanModelTests.swift
@@ -407,42 +407,42 @@ struct LoanModelTests {
         #expect(allLoansBefore.map(\.id) == allLoansAfter.map(\.id))
         #expect(allLoansBefore.map(\.isReturned) == allLoansAfter.map(\.isReturned))
     }
-
+    
     /// 初回の貸出では節目に達しないことのテスト
     @Test("初回の貸出は節目に達しないテスト")
     @MainActor
     func achievedMilestonesForFirstLoan() throws {
         let (_, _, _, loanModel, testBook, testUser) = try createLoanModel()
-
+        
         let loan = try loanModel.lendBook(bookId: testBook.id, userId: testUser.id)
-
+        
         #expect(loanModel.achievedMilestones(for: loan).isEmpty)
     }
-
+    
     /// 同じ図書を5回借りると節目に達することのテスト
     @Test("同じ図書の5回目の貸出で節目に達するテスト")
     @MainActor
     func achievedMilestonesForRepeatedBook() throws {
         let (_, _, _, loanModel, testBook, testUser) = try createLoanModel()
-
+        
         // 4回借りて返す
         for _ in 1...4 {
             let loan = try loanModel.lendBook(bookId: testBook.id, userId: testUser.id)
             _ = try loanModel.returnBook(loanId: loan.id)
         }
-
+        
         // 5回目の貸出で節目に達する
         let fifthLoan = try loanModel.lendBook(bookId: testBook.id, userId: testUser.id)
-
+        
         #expect(loanModel.achievedMilestones(for: fifthLoan) == [.repeatedBook(count: 5)])
     }
-
+    
     /// 10種類目の図書を借りると節目に達することのテスト
     @Test("10種類目の図書の貸出で節目に達するテスト")
     @MainActor
     func achievedMilestonesForDistinctBooks() throws {
         let (mockRepositoryFactory, _, _, loanModel, testBook, testUser) = try createLoanModel()
-
+        
         // 最初の図書を含めて9種類を借りて返す
         var loan = try loanModel.lendBook(bookId: testBook.id, userId: testUser.id)
         _ = try loanModel.returnBook(loanId: loan.id)
@@ -451,11 +451,11 @@ struct LoanModelTests {
             loan = try loanModel.lendBook(bookId: book.id, userId: testUser.id)
             _ = try loanModel.returnBook(loanId: loan.id)
         }
-
+        
         // 10種類目の貸出で節目に達する
         let tenthBook = try mockRepositoryFactory.bookRepository.save(Book(title: "図書10"))
         let tenthLoan = try loanModel.lendBook(bookId: tenthBook.id, userId: testUser.id)
-
+        
         #expect(loanModel.achievedMilestones(for: tenthLoan) == [.distinctBooks(count: 10)])
     }
 }

--- a/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/Views/CelebrationFeedbackView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/Views/CelebrationFeedbackView.swift
@@ -1,0 +1,326 @@
+import SwiftUI
+
+/// お祝いフィードバックの表示状態
+///
+/// 貸出が節目に達したときの紙吹雪＋メッセージカードの表示を制御します。
+/// `SuccessFeedback` と同じ作法（自動消滅・`occurrenceCount` による再発火）に、
+/// タップでスキップできる点が加わります。
+public struct CelebrationFeedback: Equatable, Sendable {
+    /// フィードバックが表示中かどうか
+    public var isPresented: Bool
+    /// お祝いのタイトル（例：「10回よんだよ！」）
+    public var title: String
+    /// お祝いのメッセージ（例：「○○さん、『ぐりとぐら』を10回かりました！」）
+    public var message: String
+    /// `show(title:message:)` が呼ばれた累計回数
+    ///
+    /// SwiftUIは「値の変化」しか検知できないため、表示中にもう一度 `show` を
+    /// 呼んでも `isPresented`（true→true）では再表示を検知できない。
+    /// この値を `sensoryFeedback`・`task(id:)`・紙吹雪のシードに渡すことで、
+    /// 毎回ハプティクスが鳴り、タイマーと紙吹雪が新しい表示から再スタートする。
+    public private(set) var occurrenceCount: Int
+
+    public init() {
+        self.isPresented = false
+        self.title = ""
+        self.message = ""
+        self.occurrenceCount = 0
+    }
+
+    /// お祝いフィードバックを表示する
+    public mutating func show(title: String, message: String) {
+        self.title = title
+        self.message = message
+        isPresented = true
+        occurrenceCount += 1
+    }
+
+    /// お祝いフィードバックを非表示にする
+    public mutating func dismiss() {
+        isPresented = false
+    }
+}
+
+/// お祝いフィードバックのPresentation View
+///
+/// クラッカーのアイコンとお祝いメッセージのカードを表示します。
+/// タップスキップの判定はModifier側で行うため、カード自体はタップを透過します。
+public struct CelebrationFeedbackView: View {
+    /// クラッカーアイコンのサイズ（Dynamic Typeに追従してスケール）
+    @ScaledMetric(relativeTo: .largeTitle) private var iconSize: CGFloat = 64
+
+    let title: String
+    let message: String
+
+    private enum Layout {
+        static let spacing: CGFloat = 12
+        static let padding: CGFloat = 32
+        static let cornerRadius: CGFloat = 20
+    }
+
+    public init(title: String, message: String) {
+        self.title = title
+        self.message = message
+    }
+
+    public var body: some View {
+        VStack(spacing: Layout.spacing) {
+            Image(systemName: "party.popper.fill")
+                .font(.system(size: iconSize))
+                .foregroundStyle(.orange)
+
+            Text(title)
+                .font(.title2.bold())
+
+            Text(message)
+                .font(.title3.bold())
+                .multilineTextAlignment(.center)
+        }
+        .padding(Layout.padding)
+        .background(
+            .regularMaterial,
+            in: RoundedRectangle(cornerRadius: Layout.cornerRadius)
+        )
+        .allowsHitTesting(false)
+    }
+}
+
+/// 紙吹雪アニメーション
+///
+/// 画面下の左右から紙片が「パンッ」と舞い上がり、重力に引かれて舞い落ちる。
+/// 紙片は毎フレーム、シード付き乱数から決定的に再生成するため、
+/// 状態として保持せず軽量に描画できる。
+struct ConfettiView: View {
+    /// 紙片の散り方を決めるシード（表示ごとに変えると散り方も変わる）
+    let seed: Int
+
+    @State private var startDate = Date()
+
+    private enum Constants {
+        /// 紙片の枚数
+        static let particleCount = 90
+        /// 打ち上げから消えるまでの時間
+        static let duration: TimeInterval = 3.0
+        /// 重力加速度（pt/s²）
+        static let gravity: Double = 700
+        /// フェードアウトを開始する進行割合
+        static let fadeStart: Double = 0.7
+    }
+
+    var body: some View {
+        TimelineView(.animation) { timeline in
+            Canvas { context, size in
+                let elapsed = timeline.date.timeIntervalSince(startDate)
+                guard elapsed >= 0, elapsed <= Constants.duration else { return }
+
+                let progress = elapsed / Constants.duration
+                let opacity =
+                    progress < Constants.fadeStart
+                    ? 1.0
+                    : 1.0 - (progress - Constants.fadeStart) / (1.0 - Constants.fadeStart)
+
+                var generator = SeededRandomNumberGenerator(seed: UInt64(max(seed, 0)))
+                for _ in 0..<Constants.particleCount {
+                    let particle = ConfettiParticle(using: &generator, in: size)
+                    particle.draw(
+                        in: context,
+                        elapsed: elapsed,
+                        gravity: Constants.gravity,
+                        opacity: opacity
+                    )
+                }
+            }
+        }
+        .allowsHitTesting(false)
+        .ignoresSafeArea()
+    }
+}
+
+/// 紙吹雪の紙片1枚
+///
+/// 発射位置・初速・色・回転などをシード付き乱数から決め、
+/// 経過時間に応じた位置（放物線）と姿勢を計算して描画する。
+private struct ConfettiParticle {
+    /// 紙片の色（システムカラーから選ぶ）
+    private static let colors: [Color] = [
+        .red, .orange, .yellow, .green, .mint, .blue, .purple, .pink,
+    ]
+
+    private enum Constants {
+        /// 発射位置の左右端からの割合
+        static let launchInset: Double = 0.12
+        /// 打ち上げの基準角度（度）。左の発射台は右上へ、右の発射台は左上へ
+        static let launchAngleFromVertical: Double = 20
+        /// 打ち上げ角度のばらつき（度）
+        static let launchAngleSpread: Double = 28
+        /// 打ち上げ初速の範囲（pt/s）
+        static let speedRange: ClosedRange<Double> = 500...1100
+        /// 紙片の辺の長さの範囲（pt）
+        static let sideRange: ClosedRange<Double> = 8...14
+        /// 回転速度の範囲（rad/s）
+        static let spinSpeedRange: ClosedRange<Double> = 2...8
+        /// ひらひら（面の反転）速度の範囲（rad/s）
+        static let flutterSpeedRange: ClosedRange<Double> = 3...8
+    }
+
+    let start: CGPoint
+    let velocity: CGVector
+    let color: Color
+    let size: CGSize
+    let initialAngle: Double
+    let spinSpeed: Double
+    let flutterSpeed: Double
+    let flutterPhase: Double
+
+    init(using generator: inout some RandomNumberGenerator, in canvasSize: CGSize) {
+        let isFromLeft = Bool.random(using: &generator)
+        let launchX =
+            isFromLeft
+            ? canvasSize.width * Constants.launchInset
+            : canvasSize.width * (1 - Constants.launchInset)
+        start = CGPoint(x: launchX, y: canvasSize.height)
+
+        // 真上を基準に、左の発射台は内側（右上）へ、右の発射台は内側（左上）へ傾ける
+        let baseAngle =
+            isFromLeft
+            ? -90 + Constants.launchAngleFromVertical
+            : -90 - Constants.launchAngleFromVertical
+        let spread = Double.random(
+            in: -Constants.launchAngleSpread...Constants.launchAngleSpread, using: &generator)
+        let angle = (baseAngle + spread) * .pi / 180
+        let speed = Double.random(in: Constants.speedRange, using: &generator)
+        velocity = CGVector(dx: cos(angle) * speed, dy: sin(angle) * speed)
+
+        color = Self.colors.randomElement(using: &generator) ?? .pink
+        let side = Double.random(in: Constants.sideRange, using: &generator)
+        size = CGSize(width: side, height: side * 0.6)
+        initialAngle = Double.random(in: 0...(2 * .pi), using: &generator)
+        spinSpeed = Double.random(in: Constants.spinSpeedRange, using: &generator)
+        flutterSpeed = Double.random(in: Constants.flutterSpeedRange, using: &generator)
+        flutterPhase = Double.random(in: 0...(2 * .pi), using: &generator)
+    }
+
+    func draw(in context: GraphicsContext, elapsed: TimeInterval, gravity: Double, opacity: Double)
+    {
+        let position = CGPoint(
+            x: start.x + velocity.dx * elapsed,
+            y: start.y + velocity.dy * elapsed + 0.5 * gravity * elapsed * elapsed
+        )
+
+        // GraphicsContextは値型なので、コピーに変換をかければ他の紙片に影響しない
+        var particleContext = context
+        particleContext.opacity = opacity
+        particleContext.translateBy(x: position.x, y: position.y)
+        particleContext.rotate(by: .radians(initialAngle + spinSpeed * elapsed))
+        // ひらひら：横方向のスケールを振動させ、紙片が翻る様子を表す
+        particleContext.scaleBy(x: cos(flutterSpeed * elapsed + flutterPhase), y: 1)
+
+        let rect = CGRect(
+            x: -size.width / 2, y: -size.height / 2,
+            width: size.width, height: size.height
+        )
+        particleContext.fill(Path(rect), with: .color(color))
+    }
+}
+
+/// シード付き乱数生成器（SplitMix64）
+///
+/// 同じシードから常に同じ乱数列を生成する。紙吹雪の紙片を
+/// 毎フレーム同じ散り方で再生成するために使う。
+private struct SeededRandomNumberGenerator: RandomNumberGenerator {
+    private var state: UInt64
+
+    init(seed: UInt64) {
+        state = seed
+    }
+
+    mutating func next() -> UInt64 {
+        state &+= 0x9E37_79B9_7F4A_7C15
+        var z = state
+        z = (z ^ (z >> 30)) &* 0xBF58_476D_1CE4_E5B9
+        z = (z ^ (z >> 27)) &* 0x94D0_49BB_1331_11EB
+        return z ^ (z >> 31)
+    }
+}
+
+/// お祝いフィードバックを画面全体にオーバーレイ表示するModifier
+///
+/// 紙吹雪とメッセージカードを重ね、表示後は自動で終了する。
+/// 節目は特別な瞬間なので日常の✓カードより長く見せるが、
+/// 行列を止めないよう画面のどこかをタップすればすぐスキップできる
+/// （DESIGN_PRINCIPLES.md「フィードバック設計」の節目のお祝い）。
+private struct CelebrationFeedbackModifier: ViewModifier {
+    @Binding var feedback: CelebrationFeedback
+    /// 自動終了までの表示時間
+    let displayDuration: Duration
+
+    private enum Constants {
+        /// 出現・消滅アニメーションの時間
+        static let transitionDuration: TimeInterval = 0.3
+        /// 出現時の初期スケール
+        static let initialScale: CGFloat = 0.8
+    }
+
+    func body(content: Content) -> some View {
+        content
+            .overlay {
+                if feedback.isPresented {
+                    // 表示中の再showでも紙吹雪が最初から舞い直すよう、表示回数でidを切り替える
+                    ConfettiView(seed: feedback.occurrenceCount)
+                        .id(feedback.occurrenceCount)
+                        .overlay {
+                            CelebrationFeedbackView(
+                                title: feedback.title,
+                                message: feedback.message
+                            )
+                        }
+                        .contentShape(Rectangle())
+                        .onTapGesture { feedback.dismiss() }
+                        .transition(
+                            .scale(scale: Constants.initialScale).combined(with: .opacity))
+                }
+            }
+            .animation(
+                .spring(duration: Constants.transitionDuration), value: feedback.isPresented
+            )
+            .sensoryFeedback(.success, trigger: feedback.occurrenceCount)
+            .task(id: feedback.occurrenceCount) {
+                guard feedback.isPresented else { return }
+                try? await Task.sleep(for: displayDuration)
+                feedback.dismiss()
+            }
+    }
+}
+
+extension View {
+    /// お祝いフィードバック（紙吹雪＋メッセージカード、自動終了・タップでスキップ）をオーバーレイ表示する
+    ///
+    /// - Parameter displayDuration: 自動終了までの表示時間。既定は3.5秒
+    ///   （DESIGN_PRINCIPLES.md「フィードバック設計」の節目のお祝い：3〜4秒で自動終了）
+    public func celebrationFeedback(
+        _ feedback: Binding<CelebrationFeedback>,
+        displayDuration: Duration = .seconds(3.5)
+    ) -> some View {
+        modifier(CelebrationFeedbackModifier(feedback: feedback, displayDuration: displayDuration))
+    }
+}
+
+#Preview {
+    @Previewable @State var feedback = CelebrationFeedback()
+
+    List {
+        Button("同じ図書の節目") {
+            feedback.show(
+                title: "10回よんだよ！",
+                message: "さくらさん、『ぐりとぐら』を10回かりました！"
+            )
+        }
+        Button("いろいろな図書の節目") {
+            feedback.show(
+                title: "20冊目！",
+                message: "はるとさん、これで20冊目の図書です！おめでとう！"
+            )
+        }
+    }
+    .celebrationFeedback($feedback)
+}

--- a/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/Views/CelebrationFeedbackView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/Views/CelebrationFeedbackView.swift
@@ -19,14 +19,14 @@ public struct CelebrationFeedback: Equatable, Sendable {
     /// この値を `sensoryFeedback`・`task(id:)`・紙吹雪のシードに渡すことで、
     /// 毎回ハプティクスが鳴り、タイマーと紙吹雪が新しい表示から再スタートする。
     public private(set) var occurrenceCount: Int
-
+    
     public init() {
         self.isPresented = false
         self.title = ""
         self.message = ""
         self.occurrenceCount = 0
     }
-
+    
     /// お祝いフィードバックを表示する
     public mutating func show(title: String, message: String) {
         self.title = title
@@ -34,7 +34,7 @@ public struct CelebrationFeedback: Equatable, Sendable {
         isPresented = true
         occurrenceCount += 1
     }
-
+    
     /// お祝いフィードバックを非表示にする
     public mutating func dismiss() {
         isPresented = false
@@ -48,30 +48,30 @@ public struct CelebrationFeedback: Equatable, Sendable {
 public struct CelebrationFeedbackView: View {
     /// クラッカーアイコンのサイズ（Dynamic Typeに追従してスケール）
     @ScaledMetric(relativeTo: .largeTitle) private var iconSize: CGFloat = 64
-
+    
     let title: String
     let message: String
-
+    
     private enum Layout {
         static let spacing: CGFloat = 12
         static let padding: CGFloat = 32
         static let cornerRadius: CGFloat = 20
     }
-
+    
     public init(title: String, message: String) {
         self.title = title
         self.message = message
     }
-
+    
     public var body: some View {
         VStack(spacing: Layout.spacing) {
             Image(systemName: "party.popper.fill")
                 .font(.system(size: iconSize))
                 .foregroundStyle(.orange)
-
+            
             Text(title)
                 .font(.title2.bold())
-
+            
             Text(message)
                 .font(.title3.bold())
                 .multilineTextAlignment(.center)
@@ -93,9 +93,9 @@ public struct CelebrationFeedbackView: View {
 struct ConfettiView: View {
     /// 紙片の散り方を決めるシード（表示ごとに変えると散り方も変わる）
     let seed: Int
-
+    
     @State private var startDate = Date()
-
+    
     private enum Constants {
         /// 紙片の枚数
         static let particleCount = 90
@@ -106,19 +106,19 @@ struct ConfettiView: View {
         /// フェードアウトを開始する進行割合
         static let fadeStart: Double = 0.7
     }
-
+    
     var body: some View {
         TimelineView(.animation) { timeline in
             Canvas { context, size in
                 let elapsed = timeline.date.timeIntervalSince(startDate)
                 guard elapsed >= 0, elapsed <= Constants.duration else { return }
-
+                
                 let progress = elapsed / Constants.duration
                 let opacity =
                     progress < Constants.fadeStart
                     ? 1.0
                     : 1.0 - (progress - Constants.fadeStart) / (1.0 - Constants.fadeStart)
-
+                
                 var generator = SeededRandomNumberGenerator(seed: UInt64(max(seed, 0)))
                 for _ in 0..<Constants.particleCount {
                     let particle = ConfettiParticle(using: &generator, in: size)
@@ -162,7 +162,7 @@ private struct ConfettiParticle {
         /// ひらひら（面の反転）速度の範囲（rad/s）
         static let flutterSpeedRange: ClosedRange<Double> = 3...8
     }
-
+    
     let start: CGPoint
     let velocity: CGVector
     let color: Color
@@ -171,7 +171,7 @@ private struct ConfettiParticle {
     let spinSpeed: Double
     let flutterSpeed: Double
     let flutterPhase: Double
-
+    
     init(using generator: inout some RandomNumberGenerator, in canvasSize: CGSize) {
         let isFromLeft = Bool.random(using: &generator)
         let launchX =
@@ -179,7 +179,7 @@ private struct ConfettiParticle {
             ? canvasSize.width * Constants.launchInset
             : canvasSize.width * (1 - Constants.launchInset)
         start = CGPoint(x: launchX, y: canvasSize.height)
-
+        
         // 真上を基準に、左の発射台は内側（右上）へ、右の発射台は内側（左上）へ傾ける
         let baseAngle =
             isFromLeft
@@ -190,7 +190,7 @@ private struct ConfettiParticle {
         let angle = (baseAngle + spread) * .pi / 180
         let speed = Double.random(in: Constants.speedRange, using: &generator)
         velocity = CGVector(dx: cos(angle) * speed, dy: sin(angle) * speed)
-
+        
         color = Self.colors.randomElement(using: &generator) ?? .pink
         let side = Double.random(in: Constants.sideRange, using: &generator)
         size = CGSize(width: side, height: side * 0.6)
@@ -199,14 +199,14 @@ private struct ConfettiParticle {
         flutterSpeed = Double.random(in: Constants.flutterSpeedRange, using: &generator)
         flutterPhase = Double.random(in: 0...(2 * .pi), using: &generator)
     }
-
+    
     func draw(in context: GraphicsContext, elapsed: TimeInterval, gravity: Double, opacity: Double)
     {
         let position = CGPoint(
             x: start.x + velocity.dx * elapsed,
             y: start.y + velocity.dy * elapsed + 0.5 * gravity * elapsed * elapsed
         )
-
+        
         // GraphicsContextは値型なので、コピーに変換をかければ他の紙片に影響しない
         var particleContext = context
         particleContext.opacity = opacity
@@ -214,7 +214,7 @@ private struct ConfettiParticle {
         particleContext.rotate(by: .radians(initialAngle + spinSpeed * elapsed))
         // ひらひら：横方向のスケールを振動させ、紙片が翻る様子を表す
         particleContext.scaleBy(x: cos(flutterSpeed * elapsed + flutterPhase), y: 1)
-
+        
         let rect = CGRect(
             x: -size.width / 2, y: -size.height / 2,
             width: size.width, height: size.height
@@ -229,11 +229,11 @@ private struct ConfettiParticle {
 /// 毎フレーム同じ散り方で再生成するために使う。
 private struct SeededRandomNumberGenerator: RandomNumberGenerator {
     private var state: UInt64
-
+    
     init(seed: UInt64) {
         state = seed
     }
-
+    
     mutating func next() -> UInt64 {
         state &+= 0x9E37_79B9_7F4A_7C15
         var z = state
@@ -253,14 +253,14 @@ private struct CelebrationFeedbackModifier: ViewModifier {
     @Binding var feedback: CelebrationFeedback
     /// 自動終了までの表示時間
     let displayDuration: Duration
-
+    
     private enum Constants {
         /// 出現・消滅アニメーションの時間
         static let transitionDuration: TimeInterval = 0.3
         /// 出現時の初期スケール
         static let initialScale: CGFloat = 0.8
     }
-
+    
     func body(content: Content) -> some View {
         content
             .overlay {
@@ -307,7 +307,7 @@ extension View {
 
 #Preview {
     @Previewable @State var feedback = CelebrationFeedback()
-
+    
     List {
         Button("同じ図書の節目") {
             feedback.show(

--- a/PictureBookLendingAdminApp/PictureBookLendingUI/Tests/CelebrationFeedbackTests.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingUI/Tests/CelebrationFeedbackTests.swift
@@ -1,0 +1,62 @@
+import XCTest
+
+@testable import PictureBookLendingUI
+
+final class CelebrationFeedbackTests: XCTestCase {
+
+    func testInitialState() {
+        let feedback = CelebrationFeedback()
+
+        XCTAssertFalse(feedback.isPresented)
+        XCTAssertEqual(feedback.title, "")
+        XCTAssertEqual(feedback.message, "")
+        XCTAssertEqual(feedback.occurrenceCount, 0)
+    }
+
+    func testShowPresentsTitleAndMessage() {
+        var feedback = CelebrationFeedback()
+
+        feedback.show(title: "10回よんだよ！", message: "さくらさんおめでとう！")
+
+        XCTAssertTrue(feedback.isPresented)
+        XCTAssertEqual(feedback.title, "10回よんだよ！")
+        XCTAssertEqual(feedback.message, "さくらさんおめでとう！")
+        XCTAssertEqual(feedback.occurrenceCount, 1)
+    }
+
+    func testDismissHidesButKeepsContent() {
+        var feedback = CelebrationFeedback()
+        feedback.show(title: "10回よんだよ！", message: "さくらさんおめでとう！")
+
+        feedback.dismiss()
+
+        XCTAssertFalse(feedback.isPresented)
+        XCTAssertEqual(feedback.title, "10回よんだよ！")
+        XCTAssertEqual(feedback.message, "さくらさんおめでとう！")
+        XCTAssertEqual(feedback.occurrenceCount, 1)
+    }
+
+    func testConsecutiveShowsIncrementOccurrenceCount() {
+        var feedback = CelebrationFeedback()
+
+        feedback.show(title: "10回よんだよ！", message: "さくらさんおめでとう！")
+        feedback.show(title: "20冊目！", message: "はるとさんおめでとう！")
+
+        XCTAssertTrue(feedback.isPresented)
+        XCTAssertEqual(feedback.title, "20冊目！")
+        XCTAssertEqual(feedback.message, "はるとさんおめでとう！")
+        XCTAssertEqual(
+            feedback.occurrenceCount, 2, "連続表示でもハプティクス・タイマー・紙吹雪が再発火するようカウントが増える")
+    }
+
+    func testShowAfterDismissPresentsAgain() {
+        var feedback = CelebrationFeedback()
+        feedback.show(title: "10回よんだよ！", message: "さくらさんおめでとう！")
+        feedback.dismiss()
+
+        feedback.show(title: "20冊目！", message: "はるとさんおめでとう！")
+
+        XCTAssertTrue(feedback.isPresented)
+        XCTAssertEqual(feedback.occurrenceCount, 2)
+    }
+}

--- a/PictureBookLendingAdminApp/PictureBookLendingUI/Tests/CelebrationFeedbackTests.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingUI/Tests/CelebrationFeedbackTests.swift
@@ -3,59 +3,59 @@ import XCTest
 @testable import PictureBookLendingUI
 
 final class CelebrationFeedbackTests: XCTestCase {
-
+    
     func testInitialState() {
         let feedback = CelebrationFeedback()
-
+        
         XCTAssertFalse(feedback.isPresented)
         XCTAssertEqual(feedback.title, "")
         XCTAssertEqual(feedback.message, "")
         XCTAssertEqual(feedback.occurrenceCount, 0)
     }
-
+    
     func testShowPresentsTitleAndMessage() {
         var feedback = CelebrationFeedback()
-
+        
         feedback.show(title: "10回よんだよ！", message: "さくらさんおめでとう！")
-
+        
         XCTAssertTrue(feedback.isPresented)
         XCTAssertEqual(feedback.title, "10回よんだよ！")
         XCTAssertEqual(feedback.message, "さくらさんおめでとう！")
         XCTAssertEqual(feedback.occurrenceCount, 1)
     }
-
+    
     func testDismissHidesButKeepsContent() {
         var feedback = CelebrationFeedback()
         feedback.show(title: "10回よんだよ！", message: "さくらさんおめでとう！")
-
+        
         feedback.dismiss()
-
+        
         XCTAssertFalse(feedback.isPresented)
         XCTAssertEqual(feedback.title, "10回よんだよ！")
         XCTAssertEqual(feedback.message, "さくらさんおめでとう！")
         XCTAssertEqual(feedback.occurrenceCount, 1)
     }
-
+    
     func testConsecutiveShowsIncrementOccurrenceCount() {
         var feedback = CelebrationFeedback()
-
+        
         feedback.show(title: "10回よんだよ！", message: "さくらさんおめでとう！")
         feedback.show(title: "20冊目！", message: "はるとさんおめでとう！")
-
+        
         XCTAssertTrue(feedback.isPresented)
         XCTAssertEqual(feedback.title, "20冊目！")
         XCTAssertEqual(feedback.message, "はるとさんおめでとう！")
         XCTAssertEqual(
             feedback.occurrenceCount, 2, "連続表示でもハプティクス・タイマー・紙吹雪が再発火するようカウントが増える")
     }
-
+    
     func testShowAfterDismissPresentsAgain() {
         var feedback = CelebrationFeedback()
         feedback.show(title: "10回よんだよ！", message: "さくらさんおめでとう！")
         feedback.dismiss()
-
+        
         feedback.show(title: "20冊目！", message: "はるとさんおめでとう！")
-
+        
         XCTAssertTrue(feedback.isPresented)
         XCTAssertEqual(feedback.occurrenceCount, 2)
     }

--- a/docs/TERMS.md
+++ b/docs/TERMS.md
@@ -17,3 +17,6 @@
 | 貸出期間 | loanPeriod | 貸出日数, 借用期間, lendingDuration, borrowingPeriod | 図書を貸し出してから返却期限までの日数（例：14日間） |
 | あいまい検索 | fuzzy search | 曖昧検索, サジェスト, 検索候補, オートコンプリート | 部分一致で0件のとき、タイプミス（Levenshtein類似度）を許容して図書を探す検索フォールバック |
 | バックアップ | BackupSnapshot | エクスポートデータ, データ移行ファイル | 組・利用者・図書・貸出記録・貸出設定・図書画像を1つにまとめたデータ。端末変更やApple ID切替時のデータ引き継ぎに使用する |
+| 節目 | LoanMilestone | 実績, バッジ, Achievement, Badge | 貸出がお祝いに値する記念の回数に達したこと。同じ図書の繰り返し（repeatedBook：5回ごと）・連続週の貸出（consecutiveWeeks：4週ごと）・図書の種類数（distinctBooks：10冊ごと）の3種類。判定は`LoanMilestoneEvaluator`が行う |
+| お祝い | CelebrationFeedback | 演出, エフェクト, Effect | 節目に達したときに表示する紙吹雪＋メッセージカード。自動終了し、画面タップでスキップできる（DESIGN_PRINCIPLES「節目のお祝い」） |
+| 紙吹雪 | confetti | 花吹雪, パーティクル, particle | お祝い表示の背景で紙片が舞うアニメーション |

--- a/docs/TERMS.md
+++ b/docs/TERMS.md
@@ -17,6 +17,6 @@
 | 貸出期間 | loanPeriod | 貸出日数, 借用期間, lendingDuration, borrowingPeriod | 図書を貸し出してから返却期限までの日数（例：14日間） |
 | あいまい検索 | fuzzy search | 曖昧検索, サジェスト, 検索候補, オートコンプリート | 部分一致で0件のとき、タイプミス（Levenshtein類似度）を許容して図書を探す検索フォールバック |
 | バックアップ | BackupSnapshot | エクスポートデータ, データ移行ファイル | 組・利用者・図書・貸出記録・貸出設定・図書画像を1つにまとめたデータ。端末変更やApple ID切替時のデータ引き継ぎに使用する |
-| 節目 | LoanMilestone | 実績, バッジ, Achievement, Badge | 貸出がお祝いに値する記念の回数に達したこと。同じ図書の繰り返し（repeatedBook：5回ごと）・連続週の貸出（consecutiveWeeks：4週ごと）・図書の種類数（distinctBooks：10冊ごと）の3種類。判定は`LoanMilestoneEvaluator`が行う |
+| 節目 | LoanMilestone | 実績, バッジ, Achievement, Badge | 貸出がお祝いに値する記念の回数に達したこと。同じ図書の繰り返し（repeatedBook：5回・10回）・連続週の貸出（consecutiveWeeks：4週・12週・24週・36週）・図書の種類数（distinctBooks：10冊・30冊・50冊）の3種類。上の節目ほど間隔が広がる階段式。判定は`LoanMilestoneEvaluator`が行う |
 | お祝い | CelebrationFeedback | 演出, エフェクト, Effect | 節目に達したときに表示する紙吹雪＋メッセージカード。自動終了し、画面タップでスキップできる（DESIGN_PRINCIPLES「節目のお祝い」） |
 | 紙吹雪 | confetti | 花吹雪, パーティクル, particle | お祝い表示の背景で紙片が舞うアニメーション |


### PR DESCRIPTION
## 概要

貸出時に節目（同じ図書の繰り返し・連続週・図書の種類数）を達成したら、通常の✓カードの代わりに紙吹雪＋お祝いカードを表示します。

## 変更内容

- **Domain層**: `LoanMilestone`（節目enum）・`LoanMilestoneEvaluator`（判定ロジック、純粋計算）＋テスト
- **Model層**: `LoanModel.achievedMilestones(for:)`＋テスト
- **UI層**: `CelebrationFeedback` state / `CelebrationFeedbackView` / `ConfettiView`（TimelineView＋Canvas、シード付き乱数で毎フレーム決定的に再生成）/ ViewModifier＋View拡張＋テスト
- **App層**: `LoanMilestone+Formatter`（お祝い文言）、`BorrowSheetContainerView`への組み込み
- **App層(DEBUG)**: UIカタログタブに発火確認ボタン3種を追加（貸出履歴なしでレビュー可能）
- **docs/TERMS.md**: 用語追加

## 節目の設計（階段式）

毎週借りる園児だと等間隔ではお祝いが月1回以上発火して特別感が薄れるため、上の節目ほど間隔が広がる階段式です（熱心に借りる園児でも年5〜7回程度）：

| 節目 | 発火回数 |
|---|---|
| 同じ図書の繰り返し | 5回・10回のみ |
| 連続週の貸出 | 4・12・24・36週（≒1ヶ月・学期・半年・通年） |
| 図書の種類数 | 10・30・50冊 |

- 同時達成時は優先度最高の1つだけを祝う（同じ図書 > 連続週 > 種類数）
- 表示は3.5秒で自動終了、画面タップでスキップ可（行列を止めない）
- お祝い終了後は✓カードと同じ作法でシートを閉じ次の貸出へ

## 確認済み

- [x] swift format lint（警告ゼロ）
- [x] プロジェクト全体ビルド＋全テスト成功（iPad Air 13-inch (M3)シミュレータ）
- [x] 節目判定はTDD（Red→Green）で階段式に変更、境界テスト追加（8週・15回・20冊は発火しない等）
- [x] シミュレータ実機動作確認：シードデータ（返却済み貸出4件）投入後、同じ絵本の5回目の貸出で紙吹雪＋「5回よんだよ！」カードの表示を確認（打ち上げ→舞い落ちるアニメーションも撮影確認済み）

## レビュー観点

- アニメーション・ハプティクス系のため「実機確認＋レビューしてからマージ」対象です
- 確認はDEBUGビルドの**カタログタブ最上部のボタン**からいつでも発火できます
- iPad 13インチの大画面では紙片90枚がややまばらに見える印象。密度・サイズ感は実機で調整の余地あり

🤖 Generated with [Claude Code](https://claude.com/claude-code)