### PR TITLE
fix: 五十音チップ切り替え時に図書一覧を先頭へスクロールする

### DIFF
--- a/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/Book/BookListView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/Book/BookListView.swift
@@ -186,11 +186,21 @@ public struct BookListView<RowAction: View>: View {
             }
             .onChange(of: scrollToTopTrigger) { _, _ in
                 // 貸出完了後の「次の貸出への引き継ぎ」：一覧を先頭へ戻す
-                guard let firstBookId = sections.first?.books.first?.id else { return }
-                withAnimation {
-                    proxy.scrollTo(firstBookId, anchor: Layout.listTopAnchor)
-                }
+                scrollToTop(proxy: proxy)
             }
+            .onChange(of: selectedKanaFilter) { _, _ in
+                // 五十音チップの切り替え時、スクロール位置が途中のままだと
+                // 絞り込み後のどこを見ているか分かりづらいため先頭へ戻す
+                scrollToTop(proxy: proxy)
+            }
+        }
+    }
+    
+    /// 一覧を先頭行までスクロールする
+    private func scrollToTop(proxy: ScrollViewProxy) {
+        guard let firstBookId = sections.first?.books.first?.id else { return }
+        withAnimation {
+            proxy.scrollTo(firstBookId, anchor: Layout.listTopAnchor)
         }
     }
     


### PR DESCRIPTION
## Summary
- 貸出一覧の五十音チップ（「あ」「か」「さ」...）を切り替えたとき、スクロール位置が途中のまま残ってしまい、絞り込み後にどこを見ているか分かりづらい問題を修正
- 貸出完了時と同じ「一覧先頭へスクロール」処理を、チップ切り替え時にも適用（`BookListView`共通コンポーネントの修正のため、貸出タブ・設定の図書一覧の両方に反映）

## Test plan
- [x] `swift build`（PictureBookLendingUI）
- [x] `swift test`（PictureBookLendingUI）
- [x] `swift format lint`
- [ ] 実機/シミュレータでチップ切り替え時のスクロール位置を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)