### PR TITLE
fix: 貸出・返却画面の組チップを組一覧の順序どおりに表示する

### DIFF
--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Borrow/BorrowSheetContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Borrow/BorrowSheetContainerView.swift
@@ -208,7 +208,7 @@ struct BorrowSheetContainerView: View {
     
     // MARK: - Computed Properties
     
-    /// 利用者選択画面の組セクション（組ごとに名前順）
+    /// 利用者選択画面の組セクション（組は組一覧の並び順、組内は利用者名順）
     ///
     /// 一覧から隠すのは「別の入口から構造的に到達できる利用者」＝保護者だけ
     /// （保護者の枠は園児タップ後の家庭の画面から必ず選べる。IA_REVIEW 追記12）。
@@ -219,6 +219,11 @@ struct BorrowSheetContainerView: View {
     private var allUserSections: [BorrowerListSection] {
         let allUsers = userModel.getAllUsers()
         let entranceUsers = userModel.getFamilyEntranceUsers()
+        let classGroupOrder = Dictionary(
+            uniqueKeysWithValues: classGroupModel.getAllClassGroups().enumerated().map {
+                ($1.id, $0)
+            }
+        )
         
         // 空き枠判定の材料：借用中の利用者IDと、園児→紐づく保護者の対応表
         let borrowedUserIds = Set(loanModel.activeLoans.map { $0.user.id })
@@ -252,7 +257,14 @@ struct BorrowSheetContainerView: View {
                         }
                 )
             }
-            .sorted { $0.title < $1.title }
+            .sorted { lhs, rhs in
+                switch (classGroupOrder[lhs.id], classGroupOrder[rhs.id]) {
+                case (let l?, let r?): l < r
+                case (nil, nil): lhs.title < rhs.title
+                case (nil, _): false
+                case (_, nil): true
+                }
+            }
     }
     
     /// 貸出中の図書の説明文（「いつ戻るか」の目安を日付だけで知らせる）

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Return/ReturnListContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Return/ReturnListContainerView.swift
@@ -169,7 +169,13 @@ struct ReturnListContainerView: View {
     
     /// 組セクション単位の表示データ（既存の貸出管理・絵本一覧と同じ見た目の慣習）
     private var filteredSections: [BorrowerListSection] {
-        Dictionary(grouping: filteredEntries) { $0.classGroupId }
+        let classGroupOrder = Dictionary(
+            uniqueKeysWithValues: classGroupModel.getAllClassGroups().enumerated().map {
+                ($1.id, $0)
+            }
+        )
+        
+        return Dictionary(grouping: filteredEntries) { $0.classGroupId }
             .map { classGroupId, entries in
                 BorrowerListSection(
                     id: classGroupId,
@@ -177,7 +183,14 @@ struct ReturnListContainerView: View {
                     rows: entries.map(\.row)
                 )
             }
-            .sorted { $0.title < $1.title }
+            .sorted { lhs, rhs in
+                switch (classGroupOrder[lhs.id], classGroupOrder[rhs.id]) {
+                case (let l?, let r?): l < r
+                case (nil, nil): lhs.title < rhs.title
+                case (nil, _): false
+                case (_, nil): true
+                }
+            }
     }
     
     // MARK: - Actions


### PR DESCRIPTION
## Summary
- 「だれが借りますか？」画面（`BorrowSheetContainerView`）と返却画面（`ReturnListContainerView`）の両方で、組セクションが組名のあいうえお順に強制ソートされており、組一覧画面で設定した並び順（`ClassGroupModel`が保持するageGroup順）が無視されていた不具合を修正
- `classGroupModel.getAllClassGroups()`の順序をもとに組セクションを並べ替えるよう変更。組一覧に存在しない組（削除済み等の「未分類」扱い）のみ従来どおり名前順で末尾に回す

## Test plan
- [x] `xcodebuild build` 成功
- [x] `xcodebuild test` 全53テスト成功
- [x] iOS 27シミュレータ（iPad Pro 13-inch M5）にインストールし、オーナーが実機画面で組の並び順を確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)