### PR TITLE
fix: 貸出登録画面の絵本一覧表示を棚表示既定にする

### DIFF
--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/SettingsBookListContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Book/SettingsBookListContainerView.swift
@@ -19,7 +19,7 @@ struct SettingsBookListContainerView: View {
     @State private var alertState = AlertState()
     @State private var selectedSortType: BookSortType = .title
     /// 管理業務では著者・管理番号・貸出状況の情報密度が必要なためリストを既定にする
-    /// （貸出タブは実物の表紙との照合が主タスクなのでグリッド既定。使い分けの経緯はissue #179）
+    /// （貸出タブは実物の表紙との照合が主タスクなので棚表示既定。使い分けの経緯はissue #179）
     @State private var displayMode: BookDisplayMode = .list
     
     var body: some View {

--- a/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Borrow/BorrowListContainerView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingAdmin/Views/Borrow/BorrowListContainerView.swift
@@ -35,7 +35,7 @@ struct BorrowListContainerView: View {
     /// 図書一覧をトップへ戻すトリガ（貸出完了ごとにインクリメント）
     @State private var scrollToTopTrigger = 0
     @State private var selectedSortType: BookSortType = .title
-    @State private var displayMode: BookDisplayMode = .grid
+    @State private var displayMode: BookDisplayMode = .shelf
     /// 設定画面表示状態
     @State private var isSettingsPresented = false
     /// 一覧の表示の大きさ（「大きく表示」フローティングボタンのトグル状態）。


### PR DESCRIPTION
## Summary
- 貸出登録画面（本を選ぶ画面）の絵本一覧の初期表示を、グリッド既定から棚表示既定に変更
- 図書管理画面（設定タブ）はリスト既定のまま変更なし（issue #179の使い分け方針を踏襲）

## Test plan
- [x] `xcodebuild build`（iOS Simulator向け）成功
- [x] `xcodebuild test`（全53テスト）成功
- [x] シミュレータ実機確認：貸出タブを開くと棚表示（木の本棚デザイン）が既定で表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)