### PR TITLE
fix: 返却画面の組チップがiOS 27ベータ実機で消える不具合を修正

### DIFF
--- a/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/Views/BorrowerListView.swift
+++ b/PictureBookLendingAdminApp/PictureBookLendingUI/Sources/Views/BorrowerListView.swift
@@ -161,17 +161,14 @@ public struct BorrowerListView: View {
     /// チップは借用者がいる組だけ表示する（押しても何も起きないチップを作らない）。
     private func indexSection(proxy: ScrollViewProxy) -> some View {
         HStack(spacing: Layout.chipSpacing) {
-            ScrollView(.horizontal) {
-                HStack(spacing: Layout.chipSpacing) {
-                    ForEach(sections) { section in
-                        Button(section.title) {
-                            handleChipTap(section: section, proxy: proxy)
-                        }
-                        .buttonStyle(.bordered)
-                        .tint(isChipSelected(section) ? Color.accentColor : .secondary)
-                    }
-                }
-                .padding(.leading)
+            // iOS 27ベータにHStack内の横ScrollViewが幅0のまま描画されない不具合があるため、
+            // ScrollViewを使わず素のHStackで並べる（絵本一覧のかなチップと同じ回避策）。
+            // 収まらない幅（狭いSplit View等）ではかなチップと同じ思想でチップを出さない
+            ViewThatFits(in: .horizontal) {
+                chipRow(proxy: proxy)
+                    .padding(.leading)
+                Color.clear
+                    .frame(width: 0, height: 0)
             }
             
             Spacer()
@@ -182,6 +179,19 @@ public struct BorrowerListView: View {
                     .buttonStyle(.bordered)
                     .tint(isOverdueOnly.wrappedValue ? .red : .secondary)
                     .padding(.trailing)
+            }
+        }
+    }
+    
+    /// 組チップの並び（`ViewThatFits`の各候補から共通で参照する）
+    private func chipRow(proxy: ScrollViewProxy) -> some View {
+        HStack(spacing: Layout.chipSpacing) {
+            ForEach(sections) { section in
+                Button(section.title) {
+                    handleChipTap(section: section, proxy: proxy)
+                }
+                .buttonStyle(.bordered)
+                .tint(isChipSelected(section) ? Color.accentColor : .secondary)
             }
         }
     }


### PR DESCRIPTION
## Summary
- 返却画面（貸出フローの利用者選択と共用の`BorrowerListView`）の組チップが、iOS 27ベータ実機限定で消える不具合を修正
- 原因は`HStack`内に`ScrollView(.horizontal)`を置く構造で、絵本一覧のかなチップ（PR #203）で既に踏んでいたのと同じレイアウト不具合
- 絵本一覧と同じ`ViewThatFits`+素の`HStack`パターンに置き換えて回避

## Test plan
- [x] `swift build`（PictureBookLendingUI）成功を確認
- [x] シミュレータ（iOS 27.0）で返却タブの組チップ表示を確認（正常）
- [ ] 実機ベータでの表示確認（元の不具合は実機限定再現のため、シミュレータでの確認だけでは直った証明にならない。実機トラブルシュート後に確認予定）
- [ ] 独立レビュー（別セッション）

🤖 Generated with [Claude Code](https://claude.com/claude-code)